### PR TITLE
fix bool convertion with GCC 4.8 (again) and __linux__ (again)

### DIFF
--- a/include/logicalaccess/services/accesscontrol/formats/customformat/datafield.hpp
+++ b/include/logicalaccess/services/accesscontrol/formats/customformat/datafield.hpp
@@ -14,7 +14,7 @@
 
 #include "logicalaccess/logs.hpp"
 
-#ifdef __linux__
+#if defined(__unix__)
 enum ParityType { PARITY_EVEN, PARITY_ODD, PARITY_NONE };
 #endif
 

--- a/plugins/pluginsreaderproviders/rwk400/rwk400readerunit.cpp
+++ b/plugins/pluginsreaderproviders/rwk400/rwk400readerunit.cpp
@@ -203,7 +203,7 @@ namespace logicalaccess
 
 	bool Rwk400ReaderUnit::isConnected()
 	{
-		return (d_insertedChip);
+		return bool(d_insertedChip);
 	}
 
 	bool Rwk400ReaderUnit::connectToReader()

--- a/src/logs.cpp
+++ b/src/logs.cpp
@@ -234,7 +234,7 @@ namespace logicalaccess
 			memset(buffer, 0x00, sizeof(buffer));
 			va_list args;
 			va_start (args, format);
-	#ifdef __linux__
+	#if denifed(__unix__)
 			vsnprintf(buffer, sizeof(buffer) - 1, format, args);
 	#else
 			_vsnprintf_s(buffer, sizeof(buffer) - 1, format, args);

--- a/src/readerproviders/serialportdatatransport.cpp
+++ b/src/readerproviders/serialportdatatransport.cpp
@@ -184,7 +184,7 @@ namespace logicalaccess
 				std::string portn = port->getSerialPort()->deviceName();
 				WARNING_("Exception received {%s} ! Sleeping {%d} milliseconds -> Reopen serial port {%s} -> Finally retry  to configure...",
 							e.what(), Settings::getInstance()->ConfigurationRetryTimeout, portn.c_str());
-#ifndef __linux__
+#if !defined(__unix__)
 				Sleep(Settings::getInstance()->ConfigurationRetryTimeout);
 #else
 				sleep(Settings::getInstance()->ConfigurationRetryTimeout);

--- a/src/readerproviders/tcpdatatransport.cpp
+++ b/src/readerproviders/tcpdatatransport.cpp
@@ -67,7 +67,7 @@ namespace logicalaccess
 			}
 		}
 
-		return (d_socket);
+		return bool(d_socket);
 	}
 
 	void TcpDataTransport::disconnect()
@@ -82,7 +82,7 @@ namespace logicalaccess
 
 	bool TcpDataTransport::isConnected()
 	{
-		return (d_socket);
+		return bool(d_socket);
 	}
 
 	std::string TcpDataTransport::getName() const

--- a/src/readerproviders/udpdatatransport.cpp
+++ b/src/readerproviders/udpdatatransport.cpp
@@ -65,7 +65,7 @@ namespace logicalaccess
 			}
 		}
 
-		return (d_socket);
+		return bool(d_socket);
 	}
 
 	void UdpDataTransport::disconnect()
@@ -79,7 +79,7 @@ namespace logicalaccess
 
 	bool UdpDataTransport::isConnected()
 	{
-		return (d_socket);
+		return bool(d_socket);
 	}
 
 	std::string UdpDataTransport::getName() const

--- a/src/services/accesscontrol/encodings/bigendiandatarepresentation.cpp
+++ b/src/services/accesscontrol/encodings/bigendiandatarepresentation.cpp
@@ -7,7 +7,7 @@
 #include "logicalaccess/services/accesscontrol/encodings/bigendiandatarepresentation.hpp"
 #include "logicalaccess/services/accesscontrol/formats/bithelper.hpp"
 
-#ifdef __linux__
+#if defined(__unix__)
 #include <cstring>
 #endif
 

--- a/src/services/accesscontrol/formats/customformat/binarydatafield.cpp
+++ b/src/services/accesscontrol/formats/customformat/binarydatafield.cpp
@@ -8,7 +8,7 @@
 #include "logicalaccess/services/accesscontrol/formats/bithelper.hpp"
 #include "logicalaccess/services/accesscontrol/formats/customformat/binarydatafield.hpp"
 
-#ifdef __linux__
+#if defined(__unix__)
 #include <cstring>
 #endif
 


### PR DESCRIPTION
Please, take care of implicit conversion as mentioned in a previous (now closed) issue.

Also don't forget to use "**unix**" instead of "**linux**" when there is no reason to use **linux**.
