### PR TITLE
Fix a logging bug for dynamic lib loading exception

### DIFF
--- a/src/dynlibrary/posixdynlibrary.cpp
+++ b/src/dynlibrary/posixdynlibrary.cpp
@@ -22,7 +22,7 @@ namespace logicalaccess
     sym = ::dlsym(_handle, symName);
     err = ::dlerror();
     if (err)
-      THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, ::dlerror());
+      THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, err);
     return sym;
   }
 }


### PR DESCRIPTION
The ::dlerror() will return NULL in the logging macro, so that the exception won't be logged correctly.
