### PR TITLE
Fix MSVC 2013 compiling error C2440

### DIFF
--- a/plugins/pluginsreaderproviders/keyboard/keyboardreaderunit.cpp
+++ b/plugins/pluginsreaderproviders/keyboard/keyboardreaderunit.cpp
@@ -247,7 +247,7 @@ namespace logicalaccess
 
 	bool KeyboardReaderUnit::connect()
 	{
-		return (d_insertedChip);
+		return (bool)d_insertedChip;
 	}
 
 	void KeyboardReaderUnit::disconnect()
@@ -283,7 +283,7 @@ namespace logicalaccess
 
 	bool KeyboardReaderUnit::isConnected()
 	{
-		return (d_insertedChip);
+		return (bool)d_insertedChip;
 	}
 
 	bool KeyboardReaderUnit::connectToReader()

--- a/plugins/pluginsreaderproviders/rfideas/rfideasreaderunit.cpp
+++ b/plugins/pluginsreaderproviders/rfideas/rfideasreaderunit.cpp
@@ -322,7 +322,7 @@ namespace logicalaccess
 
 	bool RFIDeasReaderUnit::isConnected()
 	{
-		return (d_insertedChip);
+		return (bool)d_insertedChip;
 	}
 
 	void RFIDeasReaderUnit::serialize(boost::property_tree::ptree& parentNode)


### PR DESCRIPTION
MSVC doesn't understand return shared_ptr as bool.
