### PR TITLE
Small improvement on logging.

### DIFF
--- a/include/logicalaccess/logs.hpp
+++ b/include/logicalaccess/logs.hpp
@@ -43,6 +43,12 @@ namespace logicalaccess
 
         static std::ofstream logfile;
 
+        /**
+        * Do we duplicate the log to stderr?
+        * Defaults to false.
+        */
+        static bool logToStderr;
+
     private:
         enum LogLevel		d_level;
         std::stringstream   _stream;

--- a/include/logicalaccess/settings.hpp
+++ b/include/logicalaccess/settings.hpp
@@ -37,6 +37,7 @@ namespace logicalaccess
         /* Logs */
         bool IsLogEnabled;
         std::string LogFileName;
+        bool LogToStderr;
         bool SeeWaitInsertionLog;
         bool SeeWaitRemovalLog;
         bool SeeCommunicationLog;

--- a/liblogicalaccess.config
+++ b/liblogicalaccess.config
@@ -3,6 +3,7 @@
 	<log>
 		<enabled>false</enabled>
 		<filename>liblogicalaccess.log</filename>
+		<to_stderr>false</to_stderr>
 		<seewaitinsertion>false</seewaitinsertion>
 		<seewaitremoval>false</seewaitremoval>
 		<seecommunication>false</seecommunication>

--- a/src/logs.cpp
+++ b/src/logs.cpp
@@ -8,6 +8,7 @@
 
 namespace logicalaccess
 {
+    bool Logs::logToStderr = false;
     std::ofstream Logs::logfile;
     std::map<LogLevel, std::string> Logs::logLevelMsg;
 
@@ -46,6 +47,9 @@ namespace logicalaccess
             _stream << std::endl;
             logfile << _stream.rdbuf();
             logfile.flush();
+
+            if (logToStderr)
+                std::cerr << _stream.str();
         }
     }
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -49,7 +49,8 @@ namespace logicalaccess
             if (IsLogEnabled && !Logs::logfile.is_open())
             {
 #ifdef __linux__
-                Logs::logfile.open(("/var/log/" + LogFileName), std::ios::out | std::ios::app);
+                Logs::logToStderr = LogToStderr;
+                Logs::logfile.open(LogFileName, std::ios::out | std::ios::app);
 #else
                 Logs::logfile.open((getDllPath() + "/" + LogFileName), std::ios::out | std::ios::app);
 #endif
@@ -112,6 +113,7 @@ namespace logicalaccess
 
             IsLogEnabled = pt.get("config.log.enabled", false);
             LogFileName = pt.get<std::string>("config.log.filename", "liblogicalaccess.log");
+            LogToStderr = pt.get<bool>("config.log.to_stderr", false);
             SeeWaitInsertionLog = pt.get("config.log.seewaitinsertion", false);
             SeeWaitRemovalLog = pt.get("config.log.seewaitremoval", false);
             SeeCommunicationLog = pt.get("config.log.seecommunication", false);


### PR DESCRIPTION
+ Adds an option "to_stderr" (which defaults to false) to duplicate
the log messages to the standard error output.

+ Change the behavior of the "filename" option on Linux: we do not
prefix the user-provided filename by "/var/log" anymore. This give
the user more choice over the file location, and does not require
privilege to write to /var/log anymore.