### PR TITLE
Use `serialize()` / unSerialize()` from base XmlSerialize class.

### DIFF
--- a/include/logicalaccess/cards/tripledeskey.hpp
+++ b/include/logicalaccess/cards/tripledeskey.hpp
@@ -22,6 +22,8 @@ namespace logicalaccess
     class LIBLOGICALACCESS_API TripleDESKey : public Key
     {
     public:
+        using XmlSerializable::serialize;
+        using XmlSerializable::unSerialize;
 
         /**
          * \brief Build an empty 16-bytes triple DES key.
@@ -64,19 +66,19 @@ namespace logicalaccess
          * \param parentNode The parent node.
          * \return The XML string.
          */
-        virtual void serialize(boost::property_tree::ptree& parentNode);
+        virtual void serialize(boost::property_tree::ptree& parentNode) override;
 
         /**
          * \brief UnSerialize a XML node to the current object.
          * \param node The XML node.
          */
-        virtual void unSerialize(boost::property_tree::ptree& node);
+        virtual void unSerialize(boost::property_tree::ptree& node) override;
 
         /**
          * \brief Get the default Xml Node name for this object.
          * \return The Xml node name.
          */
-        virtual std::string getDefaultXmlNodeName() const;
+        virtual std::string getDefaultXmlNodeName() const override;
 
     private:
 

--- a/include/logicalaccess/readerproviders/readerconfiguration.hpp
+++ b/include/logicalaccess/readerproviders/readerconfiguration.hpp
@@ -27,6 +27,8 @@ namespace logicalaccess
     class LIBLOGICALACCESS_API ReaderConfiguration : public XmlSerializable
     {
     public:
+        using XmlSerializable::serialize;
+        using XmlSerializable::unSerialize;
 
         /**
          * \brief Constructor.
@@ -42,19 +44,19 @@ namespace logicalaccess
          * \brief Serialize the current object to XML.
          * \param parentNode The parent node.
          */
-        virtual void serialize(boost::property_tree::ptree& parentNode);
+        virtual void serialize(boost::property_tree::ptree& parentNode) override;
 
         /**
          * \brief UnSerialize a XML node to the current object.
          * \param node The XML node.
          */
-        virtual void unSerialize(boost::property_tree::ptree& node);
+        virtual void unSerialize(boost::property_tree::ptree& node) override;
 
         /**
          * \brief Get the default Xml Node name for this object.
          * \return The Xml node name.
          */
-        virtual std::string getDefaultXmlNodeName() const;
+        virtual std::string getDefaultXmlNodeName() const override;
 
         /**
          * \brief Get the reader provider.

--- a/include/logicalaccess/readerproviders/readerunit.hpp
+++ b/include/logicalaccess/readerproviders/readerunit.hpp
@@ -41,6 +41,8 @@ namespace logicalaccess
     class LIBLOGICALACCESS_API ReaderUnit : public XmlSerializable, public std::enable_shared_from_this < ReaderUnit >
     {
     public:
+        using XmlSerializable::serialize;
+        using XmlSerializable::unSerialize;
 
         /**
          * \brief Constructor.
@@ -239,19 +241,19 @@ namespace logicalaccess
          * \brief Get the default Xml Node name for this object.
          * \return The Xml node name.
          */
-        virtual std::string getDefaultXmlNodeName() const;
+        virtual std::string getDefaultXmlNodeName() const override;
 
         /**
          * \brief Serialize the current object to XML.
          * \param parentNode The parent node.
          */
-        virtual void serialize(boost::property_tree::ptree& node);
+        virtual void serialize(boost::property_tree::ptree& node) override;
 
         /**
          * \brief UnSerialize a XML node to the current object.
          * \param node The XML node.
          */
-        virtual void unSerialize(boost::property_tree::ptree& node);
+        virtual void unSerialize(boost::property_tree::ptree& node) override;
 
         /**
          * \brief UnSerialize object from a Xml node.
@@ -259,7 +261,7 @@ namespace logicalaccess
          * \param rootNode The root node.
          * \return True on success, false otherwise.
          */
-        virtual void unSerialize(boost::property_tree::ptree& node, const std::string& rootNode);
+        virtual void unSerialize(boost::property_tree::ptree& node, const std::string& rootNode) override;
 
         /**
          * \brief Get the associated reader provider.

--- a/include/logicalaccess/services/accesscontrol/cardsformatcomposite.hpp
+++ b/include/logicalaccess/services/accesscontrol/cardsformatcomposite.hpp
@@ -49,6 +49,8 @@ namespace logicalaccess
     class LIBLOGICALACCESS_API CardsFormatComposite : public XmlSerializable
     {
     public:
+        using XmlSerializable::serialize;
+        using XmlSerializable::unSerialize;
 
         /**
          * \brief Constructor.
@@ -117,19 +119,19 @@ namespace logicalaccess
          * \brief Serialize the current object to XML.
          * \param parentNode The parent node.
          */
-        virtual void serialize(boost::property_tree::ptree& parentNode);
+        virtual void serialize(boost::property_tree::ptree& parentNode) override;
 
         /**
          * \brief UnSerialize a XML node to the current object.
          * \param node The XML node.
          */
-        virtual void unSerialize(boost::property_tree::ptree& node);
+        virtual void unSerialize(boost::property_tree::ptree& node) override;
 
         /**
          * \brief Get the default Xml Node name for this object.
          * \return The Xml node name.
          */
-        virtual std::string getDefaultXmlNodeName() const;
+        virtual std::string getDefaultXmlNodeName() const override;
 
         /**
          * \brief Get the reader unit.
@@ -145,7 +147,7 @@ namespace logicalaccess
 
     protected:
 
-        FormatInfosList formatsList;	/**< \brief The format list configurated */
+        FormatInfosList formatsList;	/**< \brief The configured formats' list */
 
         /**
          * \brief The reader unit.

--- a/plugins/pluginscards/desfire/desfireaccessinfo.hpp
+++ b/plugins/pluginscards/desfire/desfireaccessinfo.hpp
@@ -18,6 +18,9 @@ namespace logicalaccess
     class LIBLOGICALACCESS_API DESFireAccessInfo : public AccessInfo
     {
     public:
+        using XmlSerializable::serialize;
+        using XmlSerializable::unSerialize;
+
         /**
          * \brief Constructor.
          */
@@ -43,13 +46,13 @@ namespace logicalaccess
          * \brief Serialize the current object to XML.
          * \param parentNode The parent node.
          */
-        virtual void serialize(boost::property_tree::ptree& parentNode);
+        virtual void serialize(boost::property_tree::ptree& parentNode) override;
 
         /**
          * \brief UnSerialize a XML node to the current object.
          * \param node The XML node.
          */
-        virtual void unSerialize(boost::property_tree::ptree& node);
+        virtual void unSerialize(boost::property_tree::ptree& node) override;
 
         /**
          * \brief Equality operator
@@ -62,7 +65,7 @@ namespace logicalaccess
          * \brief Get the default Xml Node name for this object.
          * \return The Xml node name.
          */
-        virtual std::string getDefaultXmlNodeName() const;
+        virtual std::string getDefaultXmlNodeName() const override;
 
     public:
         /**

--- a/plugins/pluginscards/desfire/desfireaccessinfos.cpp
+++ b/plugins/pluginscards/desfire/desfireaccessinfos.cpp
@@ -70,12 +70,12 @@ namespace logicalaccess
     {
         LOG(LogLevel::INFOS) << "Unserializing access information...";
 
-        std::dynamic_pointer_cast<XmlSerializable>(readKey)->unSerialize(node.get_child("ReadKey"), "");
+        readKey->unSerialize(node.get_child("ReadKey"), "");
         readKeyno = node.get_child("ReadKeyno").get_value<unsigned char>();
-        std::dynamic_pointer_cast<XmlSerializable>(writeKey)->unSerialize(node.get_child("WriteKey"), "");
+        writeKey->unSerialize(node.get_child("WriteKey"), "");
         writeKeyno = node.get_child("WriteKeyno").get_value<unsigned char>();
-        std::dynamic_pointer_cast<XmlSerializable>(masterApplicationKey)->unSerialize(node.get_child("MasterApplicationKey"), "");
-        std::dynamic_pointer_cast<XmlSerializable>(masterCardKey)->unSerialize(node.get_child("MasterCardKey"), "");
+        masterApplicationKey->unSerialize(node.get_child("MasterApplicationKey"), "");
+        masterCardKey->unSerialize(node.get_child("MasterCardKey"), "");
     }
 
     std::string DESFireAccessInfo::getDefaultXmlNodeName() const

--- a/plugins/pluginscards/desfire/desfirekey.hpp
+++ b/plugins/pluginscards/desfire/desfirekey.hpp
@@ -42,6 +42,8 @@ namespace logicalaccess
     class LIBLOGICALACCESS_API DESFireKey : public Key
     {
     public:
+        using XmlSerializable::serialize;
+        using XmlSerializable::unSerialize;
 
         /**
          * \brief Build an empty DESFire key.
@@ -107,19 +109,19 @@ namespace logicalaccess
          * \brief Serialize the current object to XML.
          * \param parentNode The parent node.
          */
-        virtual void serialize(boost::property_tree::ptree& parentNode);
+        virtual void serialize(boost::property_tree::ptree& parentNode) override;
 
         /**
          * \brief UnSerialize a XML node to the current object.
          * \param node The XML node.
          */
-        virtual void unSerialize(boost::property_tree::ptree& node);
+        virtual void unSerialize(boost::property_tree::ptree& node) override;
 
         /**
          * \brief Get the default Xml Node name for this object.
          * \return The Xml node name.
          */
-        virtual std::string getDefaultXmlNodeName() const;
+        virtual std::string getDefaultXmlNodeName() const override;
 
         /**
          * \brief Equality operator

--- a/plugins/pluginscards/mifare/mifareaccessinfo.hpp
+++ b/plugins/pluginscards/mifare/mifareaccessinfo.hpp
@@ -23,6 +23,9 @@ namespace logicalaccess
     class LIBLOGICALACCESS_API MifareAccessInfo : public AccessInfo
     {
     public:
+        using XmlSerializable::serialize;
+        using XmlSerializable::unSerialize;
+
         /**
          * \brief Constructor.
          */
@@ -48,19 +51,19 @@ namespace logicalaccess
          * \brief Serialize the current object to XML.
          * \param parentNode The parent node.
          */
-        virtual void serialize(boost::property_tree::ptree& parentNode);
+        virtual void serialize(boost::property_tree::ptree& parentNode) override;
 
         /**
          * \brief UnSerialize a XML node to the current object.
          * \param node The XML node.
          */
-        virtual void unSerialize(boost::property_tree::ptree& parentNode);
+        virtual void unSerialize(boost::property_tree::ptree& parentNode) override;
 
         /**
          * \brief Get the default Xml Node name for this object.
          * \return The Xml node name.
          */
-        virtual std::string getDefaultXmlNodeName() const;
+        virtual std::string getDefaultXmlNodeName() const override;
 
         /**
          * \brief Equality operator

--- a/plugins/pluginscards/mifare/mifareaccessinfos.cpp
+++ b/plugins/pluginscards/mifare/mifareaccessinfos.cpp
@@ -170,8 +170,8 @@ namespace logicalaccess
 
     void MifareAccessInfo::unSerialize(boost::property_tree::ptree& node)
     {
-        std::dynamic_pointer_cast<XmlSerializable>(keyA)->unSerialize(node.get_child("KeyA"), "");
-        std::dynamic_pointer_cast<XmlSerializable>(keyB)->unSerialize(node.get_child("KeyB"), "");
+        keyA->unSerialize(node.get_child("KeyA"), "");
+        keyB->unSerialize(node.get_child("KeyB"), "");
 
         string sabstr = node.get_child("SectorAccessBits").get_value<std::string>();
         unsigned char buf[3];
@@ -194,8 +194,8 @@ namespace logicalaccess
         if (!modnode.empty())
         {
             useMAD = modnode.get_child("Use").get_value<bool>();
-            std::dynamic_pointer_cast<XmlSerializable>(madKeyA)->unSerialize(modnode.get_child("MADKeyA"), "");
-            std::dynamic_pointer_cast<XmlSerializable>(madKeyB)->unSerialize(modnode.get_child("MADKeyB"), "");
+            madKeyA->unSerialize(modnode.get_child("MADKeyA"), "");
+            madKeyB->unSerialize(modnode.get_child("MADKeyB"), "");
         }
     }
 

--- a/plugins/pluginscards/mifare/mifarekey.hpp
+++ b/plugins/pluginscards/mifare/mifarekey.hpp
@@ -22,6 +22,8 @@ namespace logicalaccess
     class LIBLOGICALACCESS_API MifareKey : public Key
     {
     public:
+        using XmlSerializable::serialize;
+        using XmlSerializable::unSerialize;
 
         /**
          * \brief Build an empty 6-bytes Mifare key.
@@ -68,19 +70,19 @@ namespace logicalaccess
          * \brief Serialize the current object to XML.
          * \param parentNode The parent node.
          */
-        virtual void serialize(boost::property_tree::ptree& parentNode);
+        virtual void serialize(boost::property_tree::ptree& parentNode) override;
 
         /**
          * \brief UnSerialize a XML node to the current object.
          * \param node The XML node.
          */
-        virtual void unSerialize(boost::property_tree::ptree& node);
+        virtual void unSerialize(boost::property_tree::ptree& node) override;
 
         /**
          * \brief Get the default Xml Node name for this object.
          * \return The Xml node name.
          */
-        virtual std::string getDefaultXmlNodeName() const;
+        virtual std::string getDefaultXmlNodeName() const override;
 
     private:
 

--- a/plugins/pluginscards/mifareplus/mifareplusaccessinfos.cpp
+++ b/plugins/pluginscards/mifareplus/mifareplusaccessinfos.cpp
@@ -122,14 +122,14 @@ namespace logicalaccess
 
     void MifarePlusAccessInfo::unSerialize(boost::property_tree::ptree& node)
     {
-        std::dynamic_pointer_cast<XmlSerializable>(keyA)->unSerialize(node.get_child("KeyA"), "");
-        std::dynamic_pointer_cast<XmlSerializable>(keyB)->unSerialize(node.get_child("KeyB"), "");
-        std::dynamic_pointer_cast<XmlSerializable>(keyOriginality)->unSerialize(node.get_child("KeyOriginality"), "");
-        std::dynamic_pointer_cast<XmlSerializable>(keyMastercard)->unSerialize(node.get_child("KeyMastercard"), "");
-        std::dynamic_pointer_cast<XmlSerializable>(keyConfiguration)->unSerialize(node.get_child("KeyConfiguration"), "");
-        std::dynamic_pointer_cast<XmlSerializable>(keySwitchL2)->unSerialize(node.get_child("KeySwitchL2"), "");
-        std::dynamic_pointer_cast<XmlSerializable>(keySwitchL3)->unSerialize(node.get_child("KeySwitchL3"), "");
-        std::dynamic_pointer_cast<XmlSerializable>(keyAuthenticateSL1AES)->unSerialize(node.get_child("KeyAuthenticateSL1AES"), "");
+        keyA->unSerialize(node.get_child("KeyA"), "");
+        keyB->unSerialize(node.get_child("KeyB"), "");
+        keyOriginality->unSerialize(node.get_child("KeyOriginality"), "");
+        keyMastercard->unSerialize(node.get_child("KeyMastercard"), "");
+        keyConfiguration->unSerialize(node.get_child("KeyConfiguration"), "");
+        keySwitchL2->unSerialize(node.get_child("KeySwitchL2"), "");
+        keySwitchL3->unSerialize(node.get_child("KeySwitchL3"), "");
+        keyAuthenticateSL1AES->unSerialize(node.get_child("KeyAuthenticateSL1AES"), "");
 
         string sabstr = node.get_child("SectorAccessBits").get_value<std::string>();
         unsigned char buf[3];
@@ -152,8 +152,8 @@ namespace logicalaccess
         if (!modnode.empty())
         {
             useMAD = modnode.get_child("Use").get_value<bool>();
-            std::dynamic_pointer_cast<XmlSerializable>(madKeyA)->unSerialize(modnode.get_child("MADKeyA"), "");
-            std::dynamic_pointer_cast<XmlSerializable>(madKeyB)->unSerialize(modnode.get_child("MADKeyB"), "");
+            madKeyA->unSerialize(modnode.get_child("MADKeyA"), "");
+            madKeyB->unSerialize(modnode.get_child("MADKeyB"), "");
         }
     }
 

--- a/plugins/pluginscards/mifareplus/mifarepluskey.hpp
+++ b/plugins/pluginscards/mifareplus/mifarepluskey.hpp
@@ -17,6 +17,8 @@ namespace logicalaccess
     class LIBLOGICALACCESS_API MifarePlusKey : public Key
     {
     public:
+        using XmlSerializable::serialize;
+        using XmlSerializable::unSerialize;
 
         /**
          * \brief Build an empty 6-bytes Mifare key.
@@ -68,19 +70,19 @@ namespace logicalaccess
          * \brief Serialize the current object to XML.
          * \param parentNode The parent node.
          */
-        virtual void serialize(boost::property_tree::ptree& parentNode);
+        virtual void serialize(boost::property_tree::ptree& parentNode) override;
 
         /**
          * \brief UnSerialize a XML node to the current object.
          * \param node The XML node.
          */
-        virtual void unSerialize(boost::property_tree::ptree& node);
+        virtual void unSerialize(boost::property_tree::ptree& node) override;
 
         /**
          * \brief Get the default Xml Node name for this object.
          * \return The Xml node name.
          */
-        virtual std::string getDefaultXmlNodeName() const;
+        virtual std::string getDefaultXmlNodeName() const override;
 
         /**
         * \brief Get the key in a buffer.

--- a/plugins/pluginscards/mifareultralight/mifareultralightcaccessinfo.hpp
+++ b/plugins/pluginscards/mifareultralight/mifareultralightcaccessinfo.hpp
@@ -18,6 +18,9 @@ namespace logicalaccess
     class LIBLOGICALACCESS_API MifareUltralightCAccessInfo : public MifareUltralightAccessInfo
     {
     public:
+        using XmlSerializable::serialize;
+        using XmlSerializable::unSerialize;
+
         /**
          * \brief Constructor.
          */
@@ -43,19 +46,19 @@ namespace logicalaccess
          * \brief Serialize the current object to XML.
          * \param parentNode The parent node.
          */
-        virtual void serialize(boost::property_tree::ptree& parentNode);
+        virtual void serialize(boost::property_tree::ptree& parentNode) override;
 
         /**
          * \brief UnSerialize a XML node to the current object.
          * \param node The XML node.
          */
-        virtual void unSerialize(boost::property_tree::ptree& node);
+        virtual void unSerialize(boost::property_tree::ptree& node) override;
 
         /**
          * \brief Get the default Xml Node name for this object.
          * \return The Xml node name.
          */
-        virtual std::string getDefaultXmlNodeName() const;
+        virtual std::string getDefaultXmlNodeName() const override;
 
         /**
          * \brief Equality operator

--- a/plugins/pluginscards/mifareultralight/mifareultralightcaccessinfos.cpp
+++ b/plugins/pluginscards/mifareultralight/mifareultralightcaccessinfos.cpp
@@ -47,7 +47,7 @@ namespace logicalaccess
     {
         MifareUltralightAccessInfo::unSerialize(node.get_child(MifareUltralightAccessInfo::getDefaultXmlNodeName()));
 
-        std::dynamic_pointer_cast<XmlSerializable>(key)->unSerialize(node.get_child("Key"), "");
+        key->unSerialize(node.get_child("Key"), "");
     }
 
     std::string MifareUltralightCAccessInfo::getDefaultXmlNodeName() const

--- a/plugins/pluginsreaderproviders/iso7816/iso7816readerunitconfiguration.cpp
+++ b/plugins/pluginsreaderproviders/iso7816/iso7816readerunitconfiguration.cpp
@@ -55,7 +55,7 @@ namespace logicalaccess
         try
         {
             d_sam_key_unlock.reset(new DESFireKey());
-            std::dynamic_pointer_cast<XmlSerializable>(d_sam_key_unlock)->unSerialize(knode, "");
+            d_sam_key_unlock->unSerialize(knode, "");
         }
         catch (std::exception& ex)
         {

--- a/plugins/pluginsreaderproviders/pcsc/readers/omnikeyxx21readerunitconfiguration.cpp
+++ b/plugins/pluginsreaderproviders/pcsc/readers/omnikeyxx21readerunitconfiguration.cpp
@@ -89,8 +89,8 @@ namespace logicalaccess
     {
         PCSCReaderUnitConfiguration::unSerialize(node.get_child(PCSCReaderUnitConfiguration::getDefaultXmlNodeName()));
         d_useSecureMode = node.get_child("UseSecureMode").get_value<bool>();
-        std::dynamic_pointer_cast<XmlSerializable>(d_secureReadKey)->unSerialize(node.get_child("SecureReadKey"), "");
-        std::dynamic_pointer_cast<XmlSerializable>(d_secureWriteKey)->unSerialize(node.get_child("SecureWriteKey"), "");
+        d_secureReadKey->unSerialize(node.get_child("SecureReadKey"), "");
+        d_secureWriteKey->unSerialize(node.get_child("SecureWriteKey"), "");
         d_encryptionMode = static_cast<HIDEncryptionMode>(node.get_child("EncryptionMode").get_value<unsigned int>());
     }
 

--- a/plugins/pluginsreaderproviders/stidstr/commands/desfireev1stidstrcommands.cpp
+++ b/plugins/pluginsreaderproviders/stidstr/commands/desfireev1stidstrcommands.cpp
@@ -392,7 +392,7 @@ namespace logicalaccess
 
     void DESFireEV1STidSTRCommands::loadKey(std::shared_ptr<DESFireKey> key)
     {
-        LOG(LogLevel::INFOS) << "Loading key from storage {" << std::dynamic_pointer_cast<XmlSerializable>(key)->serialize() << "}";
+        LOG(LogLevel::INFOS) << "Loading key from storage {" << key->serialize() << "}";
         std::shared_ptr<KeyStorage> key_storage = key->getKeyStorage();
 
         if (std::dynamic_pointer_cast<ComputerMemoryKeyStorage>(key_storage))
@@ -667,11 +667,11 @@ namespace logicalaccess
 
     void DESFireEV1STidSTRCommands::changeKey(unsigned char keyno, std::shared_ptr<DESFireKey> key)
     {
-        LOG(LogLevel::INFOS) << "Changing key... key number {0x" << std::hex << keyno << std::dec << "(" << keyno << ")} new key {" << std::dynamic_pointer_cast<XmlSerializable>(key)->serialize() << "}";
+        LOG(LogLevel::INFOS) << "Changing key... key number {0x" << std::hex << keyno << std::dec << "(" << keyno << ")} new key {" << key->serialize() << "}";
         // Only change the key if new key and old key are not the same.
         std::shared_ptr<DESFireKey> oldKey = d_profile->getKey(d_currentAid, keyno);
 
-        LOG(LogLevel::INFOS) << "Old key {" << std::dynamic_pointer_cast<XmlSerializable>(oldKey)->serialize() << "}";
+        LOG(LogLevel::INFOS) << "Old key {" << oldKey->serialize() << "}";
 
         if (key != oldKey)
         {

--- a/src/readerproviders/readerunit.cpp
+++ b/src/readerproviders/readerunit.cpp
@@ -120,7 +120,7 @@ namespace logicalaccess
 
         if (composite)
         {
-            LOG(LogLevel::INFOS) << "Composite used to find the chip identifier {" << std::dynamic_pointer_cast<XmlSerializable>(composite)->serialize() << "}";
+            LOG(LogLevel::INFOS) << "Composite used to find the chip identifier {" << composite->serialize() << "}";
             composite->setReaderUnit(shared_from_this());
 
             CardTypeList ctList = composite->getConfiguredCardTypes();


### PR DESCRIPTION
Those methods become available to the derived class which
free us from upcasting to XmlSerialize when we want to
call them.