### PR TITLE
Fix crash when card with no corresponding loaded pluging is read.

### DIFF
--- a/plugins/pluginsreaderproviders/pcsc/pcscreaderunit.cpp
+++ b/plugins/pluginsreaderproviders/pcsc/pcscreaderunit.cpp
@@ -688,12 +688,15 @@ namespace logicalaccess
                         {
                             if (d_insertedChip->getCardType() == "DESFire")
                             {
+                                auto insertedChip = std::dynamic_pointer_cast<DESFireChip>(d_insertedChip);
+                                EXCEPTION_ASSERT_WITH_LOG(insertedChip, LibLogicalAccessException, "Wrong card type: expected DESFire.");
+
                                 try
                                 {
                                     std::this_thread::sleep_for(std::chrono::milliseconds(100));
                                     DESFireCommands::DESFireCardVersion cardversion;
-                                    std::dynamic_pointer_cast<DESFireChip>(d_insertedChip)->getDESFireCommands()->selectApplication(0x00);
-                                    std::dynamic_pointer_cast<DESFireChip>(d_insertedChip)->getDESFireCommands()->getVersion(cardversion);
+                                    insertedChip->getDESFireCommands()->selectApplication(0x00);
+                                    insertedChip->getDESFireCommands()->getVersion(cardversion);
                                     // Set from the version
 
                                     // DESFire EV1 and not regular DESFire
@@ -1424,7 +1427,8 @@ namespace logicalaccess
         std::shared_ptr<Chip> chip = ReaderUnit::createChip(type);
         if (chip)
         {
-            LOG(LogLevel::INFOS) << "Chip (" << type << ") created, creating other associated objects...";
+            LOG(LogLevel::INFOS) << "Chip (" << chip->getCardType() << ") created, creating other associated objects...";
+            type = chip->getCardType(); // type may not be what we expected, it may be unsupported.
 
             std::shared_ptr<ReaderCardAdapter> rca = getReaderCardAdapter(type);
             std::shared_ptr<Commands> commands;

--- a/src/readerproviders/readerunit.cpp
+++ b/src/readerproviders/readerunit.cpp
@@ -242,11 +242,14 @@ namespace logicalaccess
 
     std::shared_ptr<Chip> ReaderUnit::createChip(std::string type)
     {
-        std::shared_ptr<Chip> ret = LibraryManager::getInstance()->getCard(type);
+        LOG(LogLevel::INFOS) << "Attempting to create a card of type (" << type << ")";
 
+        std::shared_ptr<Chip> ret = LibraryManager::getInstance()->getCard(type);
         if (!ret)
         {
-            ret.reset(new Chip(type));
+            LOG(LogLevel::NOTICES) << "Falling back to creating a default Chip object because " <<
+                    "we could'nt create a more derived object type";
+            ret.reset(new Chip("__UNSUPPORTED__" + type));
         }
 
         return ret;


### PR DESCRIPTION
Problem: Reading a DESFire card without the DESFire plugin
loaded would result in a crash.

Solution: Change the default card type when no specific Chip object
could be instancied.