### PR TITLE
Include refactoring.

### DIFF
--- a/include/logicalaccess/bufferhelper.hpp
+++ b/include/logicalaccess/bufferhelper.hpp
@@ -8,20 +8,9 @@
 #define BUFFERHELPER_HPP
 
 #include <stdint.h>
-
-#ifdef _MSC_VER
-#include "msliblogicalaccess.h"
-#else
-#ifndef LIBLOGICALACCESS_API
-#define LIBLOGICALACCESS_API
-#endif
-#ifndef DISABLE_PRAGMA_WARNING
-#define DISABLE_PRAGMA_WARNING /**< \brief winsmcrd.h was modified to support this macro, to avoid MSVC specific warnings pragma */
-#endif
-#endif
-
 #include <vector>
 #include <string>
+#include "logicalaccess/logicalaccess_api.hpp"
 
 namespace logicalaccess
 {

--- a/include/logicalaccess/cards/location.hpp
+++ b/include/logicalaccess/cards/location.hpp
@@ -7,8 +7,8 @@
 #ifndef LOGICALACCESS_LOCATION_HPP
 #define LOGICALACCESS_LOCATION_HPP
 
-#include "logicalaccess/readerproviders/readerprovider.hpp"
-#include "logicalaccess/linearizable.hpp"
+#include <string>
+#include "logicalaccess/xmlserializable.hpp"
 
 namespace logicalaccess
 {

--- a/include/logicalaccess/lla_fwd.hpp
+++ b/include/logicalaccess/lla_fwd.hpp
@@ -1,0 +1,27 @@
+//
+// Created by xaqq on 6/24/15.
+//
+
+#ifndef LIBLOGICALACCESS_LLA_FWD_HPP
+#define LIBLOGICALACCESS_LLA_FWD_HPP
+
+namespace logicalaccess
+{
+    class CardsFormatComposite;
+
+    class Chip;
+
+    class DataTransport;
+
+    class LCDDisplay;
+
+    class LEDBuzzerDisplay;
+
+    class ReaderCardAdapter;
+
+    class ReaderProvider;
+
+    class ReaderUnitConfiguration;
+}
+
+#endif //LIBLOGICALACCESS_LLA_FWD_HPP

--- a/include/logicalaccess/logicalaccess_api.hpp
+++ b/include/logicalaccess/logicalaccess_api.hpp
@@ -1,0 +1,16 @@
+//
+// Created by xaqq on 6/23/15.
+//
+
+#ifndef LIBLOGICALACCESS_LOGICALACCESS_API_HPP
+#define LIBLOGICALACCESS_LOGICALACCESS_API_HPP
+
+#ifndef LIBLOGICALACCESS_API
+#ifdef _MSC_VER
+#include "msliblogicalaccess.h"
+#else
+#define LIBLOGICALACCESS_API
+#endif
+#endif
+
+#endif //LIBLOGICALACCESS_LOGICALACCESS_API_HPP

--- a/include/logicalaccess/logs.hpp
+++ b/include/logicalaccess/logs.hpp
@@ -18,10 +18,11 @@
  */
 #define EXCEPTION_ASSERT(condition,type,msg) if (!(condition)) { throw EXCEPTION(type, msg); }
 
-#include "settings.hpp"
+#include "logicalaccess_api.hpp"
 #include <fstream>
 #include <map>
-#include <boost/date_time.hpp>
+#include <sstream>
+#include <vector>
 
 namespace logicalaccess
 {

--- a/include/logicalaccess/myexception.hpp
+++ b/include/logicalaccess/myexception.hpp
@@ -7,13 +7,11 @@
 
 #ifdef UNIX
 #define NOEXCEPT noexcept
-#ifndef LIBLOGICALACCESS_API
-#define LIBLOGICALACCESS_API
-#endif
 #else
-#include "logicalaccess/msliblogicalaccess.h"
 #define NOEXCEPT
 #endif
+
+#include "logicalaccess_api.hpp"
 
 namespace logicalaccess
 {

--- a/include/logicalaccess/readerproviders/readerunit.hpp
+++ b/include/logicalaccess/readerproviders/readerunit.hpp
@@ -7,13 +7,13 @@
 #ifndef LOGICALACCESS_READERUNIT_HPP
 #define LOGICALACCESS_READERUNIT_HPP
 
-#include "logicalaccess/readerproviders/readerunitconfiguration.hpp"
-#include "logicalaccess/readerproviders/lcddisplay.hpp"
-#include "logicalaccess/readerproviders/ledbuzzerdisplay.hpp"
-#include "logicalaccess/myexception.hpp"
-#include <map>
-#include <chrono>
-#include <thread>
+#include <stdint.h>
+#include <boost/property_tree/ptree_fwd.hpp>
+#include <memory>
+#include <string>
+#include <vector>
+#include "logicalaccess/xmlserializable.hpp"
+#include "logicalaccess/lla_fwd.hpp"
 
 #ifdef UNIX
 #include <PCSC/wintypes.h>

--- a/include/logicalaccess/readerproviders/serialport.hpp
+++ b/include/logicalaccess/readerproviders/serialport.hpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <string>
 #include <mutex>
+#include <thread>
 
 #include <boost/asio.hpp>
 #include <boost/utility.hpp>

--- a/include/logicalaccess/resultchecker.hpp
+++ b/include/logicalaccess/resultchecker.hpp
@@ -7,19 +7,7 @@
 #ifndef LOGICALACCESS_RESULTCHECKER_HPP
 #define LOGICALACCESS_RESULTCHECKER_HPP
 
-#ifdef _MSC_VER
-#include "logicalaccess/msliblogicalaccess.h"
-#else
-#ifndef LIBLOGICALACCESS_API
-#define LIBLOGICALACCESS_API
-#endif
-#ifndef DISABLE_PRAGMA_WARNING
-#define DISABLE_PRAGMA_WARNING /**< \brief winsmcrd.h was modified to support this macro, to avoid MSVC specific warnings pragma */
-#endif
-#endif
-
-#include "logicalaccess/logs.hpp"
-#include "logicalaccess/myexception.hpp"
+#include "logicalaccess_api.hpp"
 #include <iostream>
 #include <map>
 

--- a/include/logicalaccess/xmlserializable.hpp
+++ b/include/logicalaccess/xmlserializable.hpp
@@ -41,23 +41,8 @@
 #include <vector>
 #include <iostream>
 #include <sstream>
-
-#ifdef _MSC_VER
-#include "msliblogicalaccess.h"
-#else
-#ifndef LIBLOGICALACCESS_API
-#define LIBLOGICALACCESS_API
-#endif
-#ifndef DISABLE_PRAGMA_WARNING
-#define DISABLE_PRAGMA_WARNING /**< \brief winsmcrd.h was modified to support this macro, to avoid MSVC specific warnings pragma */
-#endif
-#endif
-
-#include "logicalaccess/logs.hpp"
-
-#include <boost/enable_shared_from_this.hpp>
-#include <boost/property_tree/xml_parser.hpp>
-#include <boost/property_tree/ptree.hpp>
+#include "logicalaccess/logicalaccess_api.hpp"
+#include <boost/property_tree/ptree_fwd.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/cryptolib/src/rsa_key.cpp
+++ b/plugins/cryptolib/src/rsa_key.cpp
@@ -17,6 +17,8 @@
 #include <openssl/ssl.h>
 #include <openssl/rand.h>
 
+#include <cassert>
+
 namespace logicalaccess
 {
     namespace openssl

--- a/plugins/lla-tests/utils.cpp
+++ b/plugins/lla-tests/utils.cpp
@@ -4,6 +4,7 @@
 
 #include "utils.hpp"
 #include <iostream>
+#include <thread>
 #include <sstream>
 
 #include "logicalaccess/dynlibrary/idynlibrary.hpp"

--- a/plugins/pluginscards/desfire/desfireaccessinfos.cpp
+++ b/plugins/pluginscards/desfire/desfireaccessinfos.cpp
@@ -4,6 +4,7 @@
  * \brief Access informations for DESFire card.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "desfireaccessinfo.hpp"
 #include "desfireprofile.hpp"
 #include "desfirechip.hpp"

--- a/plugins/pluginscards/desfire/desfirechip.cpp
+++ b/plugins/pluginscards/desfire/desfirechip.cpp
@@ -11,6 +11,7 @@
 
 #include <cstring>
 #include <logicalaccess/dynlibrary/librarymanager.hpp>
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginscards/desfire/desfirechip.hpp
+++ b/plugins/pluginscards/desfire/desfirechip.hpp
@@ -15,10 +15,6 @@
 #include <vector>
 #include <iostream>
 
-using std::string;
-using std::vector;
-using std::ostream;
-
 namespace logicalaccess
 {
 #define	CHIP_DESFIRE		"DESFire"

--- a/plugins/pluginscards/desfire/desfirecommands.cpp
+++ b/plugins/pluginscards/desfire/desfirecommands.cpp
@@ -6,6 +6,7 @@
 
 #include "desfirecommands.hpp"
 #include "desfirechip.hpp"
+#include <cstring>
 
 namespace logicalaccess
 {

--- a/plugins/pluginscards/desfire/desfirecrypto.cpp
+++ b/plugins/pluginscards/desfire/desfirecrypto.cpp
@@ -21,6 +21,7 @@
 #include "logicalaccess/crypto/des_symmetric_key.hpp"
 #include "logicalaccess/crypto/des_initialization_vector.hpp"
 #include "logicalaccess/crypto/cmac.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginscards/desfire/desfirecrypto.hpp
+++ b/plugins/pluginscards/desfire/desfirecrypto.hpp
@@ -16,10 +16,6 @@
 #include <vector>
 #include <iostream>
 
-using std::string;
-using std::vector;
-using std::ostream;
-
 namespace logicalaccess
 {
     /**

--- a/plugins/pluginscards/desfire/desfireev1location.cpp
+++ b/plugins/pluginscards/desfire/desfireev1location.cpp
@@ -4,6 +4,7 @@
  * \brief Location informations for DESFire EV1 card.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "desfireev1location.hpp"
 
 namespace logicalaccess

--- a/plugins/pluginscards/desfire/desfirekey.cpp
+++ b/plugins/pluginscards/desfire/desfirekey.cpp
@@ -4,6 +4,7 @@
  * \brief DESFire Key.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "desfirekey.hpp"
 
 namespace logicalaccess

--- a/plugins/pluginscards/desfire/desfirelocation.cpp
+++ b/plugins/pluginscards/desfire/desfirelocation.cpp
@@ -4,6 +4,7 @@
  * \brief Location informations for DESFire card.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "desfirelocation.hpp"
 
 namespace logicalaccess

--- a/plugins/pluginscards/desfire/desfireprofile.cpp
+++ b/plugins/pluginscards/desfire/desfireprofile.cpp
@@ -4,6 +4,7 @@
  * \brief DESFire card profiles.
  */
 
+#include <cstring>
 #include "desfireprofile.hpp"
 #include "desfirecrypto.hpp"
 

--- a/plugins/pluginscards/desfire/desfirestoragecardservice.cpp
+++ b/plugins/pluginscards/desfire/desfirestoragecardservice.cpp
@@ -6,6 +6,7 @@
 
 #include "desfirestoragecardservice.hpp"
 #include "desfireev1location.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginscards/desfire/nxpav1keydiversification.cpp
+++ b/plugins/pluginscards/desfire/nxpav1keydiversification.cpp
@@ -9,6 +9,7 @@
 #include "logicalaccess/crypto/cmac.hpp"
 #include "desfirecrypto.hpp"
 #include <vector>
+#include <boost/property_tree/ptree.hpp>
 
 #include "logicalaccess/crypto/tomcrypt.h"
 #include "logicalaccess/crypto/symmetric_key.hpp"
@@ -16,6 +17,7 @@
 #include "logicalaccess/crypto/aes_initialization_vector.hpp"
 #include "logicalaccess/crypto/des_symmetric_key.hpp"
 #include "logicalaccess/crypto/des_initialization_vector.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginscards/desfire/nxpav2keydiversification.cpp
+++ b/plugins/pluginscards/desfire/nxpav2keydiversification.cpp
@@ -9,6 +9,8 @@
 #include "logicalaccess/crypto/cmac.hpp"
 #include "desfirecrypto.hpp"
 #include <vector>
+#include <boost/property_tree/ptree.hpp>
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginscards/desfire/omnitechkeydiversification.cpp
+++ b/plugins/pluginscards/desfire/omnitechkeydiversification.cpp
@@ -5,6 +5,9 @@
 #include "logicalaccess/bufferhelper.hpp"
 #include "desfirecrypto.hpp"
 #include <vector>
+#include "logicalaccess/myexception.hpp"
+#include <cstring>
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginscards/desfire/sagemkeydiversification.cpp
+++ b/plugins/pluginscards/desfire/sagemkeydiversification.cpp
@@ -5,6 +5,9 @@
 #include "logicalaccess/bufferhelper.hpp"
 #include "desfirecrypto.hpp"
 #include <vector>
+#include "logicalaccess/myexception.hpp"
+#include <cstring>
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginscards/em4102/em4102chip.cpp
+++ b/plugins/pluginscards/em4102/em4102chip.cpp
@@ -6,20 +6,6 @@
 
 #include "em4102chip.hpp"
 
-#include <iostream>
-#include <iomanip>
-#include <sstream>
-
-using std::endl;
-using std::dec;
-using std::hex;
-using std::setfill;
-using std::setw;
-using std::ostringstream;
-using std::istringstream;
-
-#include "logicalaccess/services/accesscontrol/formats/bithelper.hpp"
-
 namespace logicalaccess
 {
     EM4102Chip::EM4102Chip()

--- a/plugins/pluginscards/iso15693/iso15693location.cpp
+++ b/plugins/pluginscards/iso15693/iso15693location.cpp
@@ -4,6 +4,7 @@
  * \brief Location informations for ISO15693 card.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "iso15693location.hpp"
 
 namespace logicalaccess

--- a/plugins/pluginscards/iso7816/iso7816location.cpp
+++ b/plugins/pluginscards/iso7816/iso7816location.cpp
@@ -11,6 +11,7 @@
 #include <cstring>
 
 #include <boost/foreach.hpp>
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginscards/iso7816/iso7816nfctag4cardservice.cpp
+++ b/plugins/pluginscards/iso7816/iso7816nfctag4cardservice.cpp
@@ -6,6 +6,7 @@
 
 #include "iso7816nfctag4cardservice.hpp"
 #include "logicalaccess/services/nfctag/ndefmessage.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginscards/iso7816/iso7816storagecardservice.cpp
+++ b/plugins/pluginscards/iso7816/iso7816storagecardservice.cpp
@@ -4,10 +4,12 @@
  * \brief ISO7816 storage card service.
  */
 
+#include <cstring>
 #include "iso7816storagecardservice.hpp"
 #include "logicalaccess/services/accesscontrol/formats/bithelper.hpp"
 #include "iso7816location.hpp"
 #include "iso7816chip.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginscards/mifare/mifareaccessinfos.cpp
+++ b/plugins/pluginscards/mifare/mifareaccessinfos.cpp
@@ -4,6 +4,9 @@
  * \brief Access informations for mifare card.
  */
 
+#include <cstring>
+#include <boost/property_tree/ptree.hpp>
+#include <iomanip>
 #include "mifareaccessinfo.hpp"
 #include "mifarechip.hpp"
 

--- a/plugins/pluginscards/mifare/mifarecommands.cpp
+++ b/plugins/pluginscards/mifare/mifarecommands.cpp
@@ -4,8 +4,10 @@
  * \brief Mifare commands.
  */
 
+#include <cstring>
 #include "mifarecommands.hpp"
 #include "mifarechip.hpp"
+#include "logicalaccess/myexception.hpp"
 
 #define PREFIX_PATTERN 0xE3
 #define POLYNOM_PATTERN 0x1D

--- a/plugins/pluginscards/mifare/mifarekey.cpp
+++ b/plugins/pluginscards/mifare/mifarekey.cpp
@@ -4,6 +4,8 @@
  * \brief Mifare Key.
  */
 
+#include <cstring>
+#include <boost/property_tree/ptree.hpp>
 #include "mifarekey.hpp"
 
 namespace logicalaccess

--- a/plugins/pluginscards/mifare/mifarelocation.cpp
+++ b/plugins/pluginscards/mifare/mifarelocation.cpp
@@ -4,6 +4,7 @@
  * \brief Location informations for Mifare card.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "mifarelocation.hpp"
 
 namespace logicalaccess

--- a/plugins/pluginscards/mifareplus/mifareplusaccessinfos.cpp
+++ b/plugins/pluginscards/mifareplus/mifareplusaccessinfos.cpp
@@ -4,6 +4,8 @@
  * \brief Access informations for mifarePlus card.
  */
 
+#include <boost/property_tree/ptree.hpp>
+#include <iomanip>
 #include "mifareplusaccessinfo.hpp"
 #include "mifarepluschip.hpp"
 

--- a/plugins/pluginscards/mifareplus/mifarepluscommands.cpp
+++ b/plugins/pluginscards/mifareplus/mifarepluscommands.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "mifarepluscommands.hpp"
-
+#include "logicalaccess/myexception.hpp"
 #include <stdlib.h>
 
 namespace logicalaccess

--- a/plugins/pluginscards/mifareplus/mifarepluscrypto.cpp
+++ b/plugins/pluginscards/mifareplus/mifarepluscrypto.cpp
@@ -18,6 +18,7 @@
 #include "logicalaccess/crypto/aes_initialization_vector.hpp"
 #include "logicalaccess/crypto/des_symmetric_key.hpp"
 #include "logicalaccess/crypto/des_initialization_vector.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginscards/mifareplus/mifarepluskey.cpp
+++ b/plugins/pluginscards/mifareplus/mifarepluskey.cpp
@@ -5,6 +5,8 @@
  */
 
 #include "mifarepluskey.hpp"
+#include <cstring>
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginscards/mifareplus/mifareplussl1commands.cpp
+++ b/plugins/pluginscards/mifareplus/mifareplussl1commands.cpp
@@ -4,8 +4,10 @@
  * \brief MifarePlus SL1 commands.
  */
 
+#include <cstring>
 #include "mifareplussl3commands.hpp"
 #include "mifarepluschip.hpp"
+#include "logicalaccess/myexception.hpp"
 
 #define PREFIX_PATTERN 0xE3
 #define POLYNOM_PATTERN 0x1D

--- a/plugins/pluginscards/mifareplus/mifareplussl1storagecardservice.cpp
+++ b/plugins/pluginscards/mifareplus/mifareplussl1storagecardservice.cpp
@@ -4,6 +4,7 @@
  * \brief MifarePlus SL1 storage card service.
  */
 
+#include <cstring>
 #include "mifareplussl1storagecardservice.hpp"
 #include "mifarepluschip.hpp"
 #include "logicalaccess/services/accesscontrol/accesscontrolcardservice.hpp"

--- a/plugins/pluginscards/mifareultralight/mifareultralightaccessinfos.cpp
+++ b/plugins/pluginscards/mifareultralight/mifareultralightaccessinfos.cpp
@@ -4,6 +4,7 @@
  * \brief Access informations for Mifare Ultralight card.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "mifareultralightaccessinfo.hpp"
 #include "mifareultralightchip.hpp"
 

--- a/plugins/pluginscards/mifareultralight/mifareultralightcaccessinfos.cpp
+++ b/plugins/pluginscards/mifareultralight/mifareultralightcaccessinfos.cpp
@@ -4,6 +4,7 @@
  * \brief Access informations for Mifare Ultralight C card.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "mifareultralightcaccessinfo.hpp"
 #include "mifareultralightcchip.hpp"
 

--- a/plugins/pluginscards/mifareultralight/mifareultralightccommands.cpp
+++ b/plugins/pluginscards/mifareultralight/mifareultralightccommands.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "mifareultralightccommands.hpp"
+#include "logicalaccess/logs.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginscards/mifareultralight/mifareultralightlocation.cpp
+++ b/plugins/pluginscards/mifareultralight/mifareultralightlocation.cpp
@@ -4,6 +4,7 @@
  * \brief Location informations for Mifare Ultralight card.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "mifareultralightlocation.hpp"
 
 namespace logicalaccess

--- a/plugins/pluginscards/prox/proxlocation.cpp
+++ b/plugins/pluginscards/prox/proxlocation.cpp
@@ -4,6 +4,7 @@
  * \brief Location informations for Prox card.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "proxlocation.hpp"
 
 namespace logicalaccess

--- a/plugins/pluginscards/samav2/sambasickeyentry.cpp
+++ b/plugins/pluginscards/samav2/sambasickeyentry.cpp
@@ -4,7 +4,11 @@
  * \brief SAMBasicKeyEntry source.
  */
 
+#include <cstring>
+#include <boost/property_tree/ptree.hpp>
 #include "sambasickeyentry.hpp"
+#include "logicalaccess/myexception.hpp"
+#include "logicalaccess/logs.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginscards/samav2/samcrypto.cpp
+++ b/plugins/pluginscards/samav2/samcrypto.cpp
@@ -9,6 +9,7 @@
 #include <ctime>
 #include <cstdlib>
 #include <climits>
+#include "logicalaccess/myexception.hpp"
 
 #ifndef UNIX
 #include "logicalaccess/msliblogicalaccess.h"

--- a/plugins/pluginscards/samav2/samcrypto.hpp
+++ b/plugins/pluginscards/samav2/samcrypto.hpp
@@ -20,10 +20,6 @@
 #include <vector>
 #include <iostream>
 
-using std::string;
-using std::vector;
-using std::ostream;
-
 namespace logicalaccess
 {
     /**

--- a/plugins/pluginscards/samav2/samkeyentry.hpp
+++ b/plugins/pluginscards/samav2/samkeyentry.hpp
@@ -7,6 +7,7 @@
 #ifndef LOGICALACCESS_SAMKEYENTRY_HPP
 #define LOGICALACCESS_SAMKEYENTRY_HPP
 
+#include <cstring>
 #include "logicalaccess/key.hpp"
 #include "sambasickeyentry.hpp"
 

--- a/plugins/pluginscards/samav2/samkucentry.hpp
+++ b/plugins/pluginscards/samav2/samkucentry.hpp
@@ -7,6 +7,7 @@
 #ifndef LOGICALACCESS_SAMKUCENTRY_HPP
 #define LOGICALACCESS_SAMKUCENTRY_HPP
 
+#include <cstring>
 #include "logicalaccess/key.hpp"
 
 namespace logicalaccess

--- a/plugins/pluginscards/twic/twiccommands.cpp
+++ b/plugins/pluginscards/twic/twiccommands.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "twiccommands.hpp"
+#include <cstring>
 
 namespace logicalaccess
 {

--- a/plugins/pluginscards/twic/twiclocation.cpp
+++ b/plugins/pluginscards/twic/twiclocation.cpp
@@ -4,6 +4,7 @@
  * \brief Location informations for Twic card.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "twiclocation.hpp"
 
 namespace logicalaccess

--- a/plugins/pluginsreaderproviders/a3mlgm5600/a3mlgm5600_fwd.hpp
+++ b/plugins/pluginsreaderproviders/a3mlgm5600/a3mlgm5600_fwd.hpp
@@ -1,0 +1,14 @@
+//
+// Created by xaqq on 6/24/15.
+//
+
+#ifndef LIBLOGICALACCESS_A3MLGM5600_FWD_HPP
+#define LIBLOGICALACCESS_A3MLGM5600_FWD_HPP
+
+namespace logicalaccess
+{
+    class A3MLGM5600ReaderCardAdapter;
+
+}
+
+#endif //LIBLOGICALACCESS_A3MLGM5600_FWD_HPP

--- a/plugins/pluginsreaderproviders/a3mlgm5600/a3mlgm5600ledbuzzerdisplay.cpp
+++ b/plugins/pluginsreaderproviders/a3mlgm5600/a3mlgm5600ledbuzzerdisplay.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "a3mlgm5600ledbuzzerdisplay.hpp"
+#include "readercardadapters/a3mlgm5600readercardadapter.hpp"
 
 #include <iostream>
 #include <iomanip>

--- a/plugins/pluginsreaderproviders/a3mlgm5600/a3mlgm5600ledbuzzerdisplay.hpp
+++ b/plugins/pluginsreaderproviders/a3mlgm5600/a3mlgm5600ledbuzzerdisplay.hpp
@@ -7,12 +7,11 @@
 #ifndef LOGICALACCESS_A3MLGM5600LEDBUZZERDISPLAY_HPP
 #define LOGICALACCESS_A3MLGM5600LEDBUZZERDISPLAY_HPP
 
-#include "readercardadapters/a3mlgm5600readercardadapter.hpp"
-
+#include "logicalaccess/logicalaccess_api.hpp"
+#include "logicalaccess/readerproviders/ledbuzzerdisplay.hpp"
+#include "a3mlgm5600_fwd.hpp"
 #include <string>
 #include <vector>
-
-#include "logicalaccess/logs.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/a3mlgm5600/a3mlgm5600readerprovider.hpp
+++ b/plugins/pluginsreaderproviders/a3mlgm5600/a3mlgm5600readerprovider.hpp
@@ -13,9 +13,6 @@
 #include <string>
 #include <vector>
 
-using std::string;
-using std::vector;
-
 #include "logicalaccess/logs.hpp"
 
 namespace logicalaccess

--- a/plugins/pluginsreaderproviders/a3mlgm5600/a3mlgm5600readerunit.cpp
+++ b/plugins/pluginsreaderproviders/a3mlgm5600/a3mlgm5600readerunit.cpp
@@ -14,6 +14,7 @@
 #include "logicalaccess/readerproviders/readerunitconfiguration.hpp"
 #include <memory>
 #include <boost/filesystem.hpp>
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/readerproviders/readerunit.hpp"
 #include "a3mlgm5600readerprovider.hpp"
 #include "logicalaccess/services/accesscontrol/cardsformatcomposite.hpp"
@@ -22,6 +23,9 @@
 #include "a3mlgm5600lcddisplay.hpp"
 #include "logicalaccess/dynlibrary/librarymanager.hpp"
 #include "logicalaccess/readerproviders/udpdatatransport.hpp"
+#include "logicalaccess/bufferhelper.hpp"
+#include "logicalaccess/myexception.hpp"
+#include <boost/property_tree/xml_parser.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/a3mlgm5600/a3mlgm5600readerunitconfiguration.cpp
+++ b/plugins/pluginsreaderproviders/a3mlgm5600/a3mlgm5600readerunitconfiguration.cpp
@@ -4,6 +4,7 @@
  * \brief A3MLGM5600 reader unit configuration.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "a3mlgm5600readerunitconfiguration.hpp"
 #include "a3mlgm5600readerprovider.hpp"
 

--- a/plugins/pluginsreaderproviders/a3mlgm5600/libraryentry.cpp
+++ b/plugins/pluginsreaderproviders/a3mlgm5600/libraryentry.cpp
@@ -2,17 +2,7 @@
 #include <memory>
 #include "logicalaccess/readerproviders/readerprovider.hpp"
 #include "a3mlgm5600readerprovider.hpp"
-
-#ifdef _MSC_VER
-#include "logicalaccess/msliblogicalaccess.h"
-#else
-#ifndef LIBLOGICALACCESS_API
-#define LIBLOGICALACCESS_API
-#endif
-#ifndef DISABLE_PRAGMA_WARNING
-#define DISABLE_PRAGMA_WARNING /**< \brief winsmcrd.h was modified to support this macro, to avoid MSVC specific warnings pragma */
-#endif
-#endif
+#include "logicalaccess/logicalaccess_api.hpp"
 
 extern "C"
 {

--- a/plugins/pluginsreaderproviders/admitto/admittoreaderprovider.cpp
+++ b/plugins/pluginsreaderproviders/admitto/admittoreaderprovider.cpp
@@ -6,6 +6,7 @@
 
 #include "admittoreaderprovider.hpp"
 #include "logicalaccess/readerproviders/serialportdatatransport.hpp"
+#include "logicalaccess/myexception.hpp"
 
 #ifdef __unix__
 #include <stdlib.h>

--- a/plugins/pluginsreaderproviders/admitto/admittoreaderunit.cpp
+++ b/plugins/pluginsreaderproviders/admitto/admittoreaderunit.cpp
@@ -18,6 +18,8 @@
 #include "logicalaccess/dynlibrary/librarymanager.hpp"
 #include "logicalaccess/dynlibrary/idynlibrary.hpp"
 #include "readercardadapters/admittodatatransport.hpp"
+#include "logicalaccess/settings.hpp"
+#include <boost/property_tree/xml_parser.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/admitto/admittoreaderunitconfiguration.cpp
+++ b/plugins/pluginsreaderproviders/admitto/admittoreaderunitconfiguration.cpp
@@ -4,6 +4,7 @@
  * \brief  Admitto reader unit configuration.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "admittoreaderunitconfiguration.hpp"
 #include "admittoreaderprovider.hpp"
 

--- a/plugins/pluginsreaderproviders/admitto/libraryentry.cpp
+++ b/plugins/pluginsreaderproviders/admitto/libraryentry.cpp
@@ -2,17 +2,7 @@
 #include <memory>
 #include "logicalaccess/readerproviders/readerprovider.hpp"
 #include "admittoreaderprovider.hpp"
-
-#ifdef _MSC_VER
-#include "logicalaccess/msliblogicalaccess.h"
-#else
-#ifndef LIBLOGICALACCESS_API
-#define LIBLOGICALACCESS_API
-#endif
-#ifndef DISABLE_PRAGMA_WARNING
-#define DISABLE_PRAGMA_WARNING /**< \brief winsmcrd.h was modified to support this macro, to avoid MSVC specific warnings pragma */
-#endif
-#endif
+#include "logicalaccess/logicalaccess_api.hpp"
 
 extern "C"
 {

--- a/plugins/pluginsreaderproviders/admitto/readercardadapters/admittodatatransport.hpp
+++ b/plugins/pluginsreaderproviders/admitto/readercardadapters/admittodatatransport.hpp
@@ -12,6 +12,7 @@
 
 #include <string>
 #include <vector>
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/axesstmc13/axesstmc13readerprovider.cpp
+++ b/plugins/pluginsreaderproviders/axesstmc13/axesstmc13readerprovider.cpp
@@ -6,6 +6,7 @@
 
 #include "axesstmc13readerprovider.hpp"
 #include "logicalaccess/readerproviders/serialportdatatransport.hpp"
+#include "logicalaccess/myexception.hpp"
 
 #ifdef __unix__
 #include <stdlib.h>
@@ -16,6 +17,7 @@
 #include <iomanip>
 
 #include "axesstmc13readerunit.hpp"
+#include "logicalaccess/logs.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/axesstmc13/axesstmc13readerunit.cpp
+++ b/plugins/pluginsreaderproviders/axesstmc13/axesstmc13readerunit.cpp
@@ -17,6 +17,8 @@
 #include "readercardadapters/axesstmc13readercardadapter.hpp"
 #include <boost/filesystem.hpp>
 #include "readercardadapters/axesstmc13datatransport.hpp"
+#include "logicalaccess/bufferhelper.hpp"
+#include <boost/property_tree/xml_parser.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/axesstmc13/axesstmc13readerunitconfiguration.cpp
+++ b/plugins/pluginsreaderproviders/axesstmc13/axesstmc13readerunitconfiguration.cpp
@@ -4,6 +4,7 @@
  * \brief  AxessTMC 13Mhz reader unit configuration.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "axesstmc13readerunitconfiguration.hpp"
 #include "axesstmc13readerprovider.hpp"
 

--- a/plugins/pluginsreaderproviders/axesstmc13/libraryentry.cpp
+++ b/plugins/pluginsreaderproviders/axesstmc13/libraryentry.cpp
@@ -2,17 +2,7 @@
 #include <memory>
 #include "logicalaccess/readerproviders/readerprovider.hpp"
 #include "axesstmc13readerprovider.hpp"
-
-#ifdef _MSC_VER
-#include "logicalaccess/msliblogicalaccess.h"
-#else
-#ifndef LIBLOGICALACCESS_API
-#define LIBLOGICALACCESS_API
-#endif
-#ifndef DISABLE_PRAGMA_WARNING
-#define DISABLE_PRAGMA_WARNING /**< \brief winsmcrd.h was modified to support this macro, to avoid MSVC specific warnings pragma */
-#endif
-#endif
+#include "logicalaccess/logicalaccess_api.hpp"
 
 extern "C"
 {

--- a/plugins/pluginsreaderproviders/axesstmc13/readercardadapters/axesstmc13datatransport.hpp
+++ b/plugins/pluginsreaderproviders/axesstmc13/readercardadapters/axesstmc13datatransport.hpp
@@ -12,6 +12,7 @@
 
 #include <string>
 #include <vector>
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/axesstmclegic/axesstmclegicreaderprovider.cpp
+++ b/plugins/pluginsreaderproviders/axesstmclegic/axesstmclegicreaderprovider.cpp
@@ -6,6 +6,7 @@
 
 #include "axesstmclegicreaderprovider.hpp"
 #include "logicalaccess/readerproviders/serialportdatatransport.hpp"
+#include "logicalaccess/myexception.hpp"
 
 #ifdef __unix__
 #include <stdlib.h>
@@ -14,6 +15,7 @@
 
 #include <sstream>
 #include <iomanip>
+#include <logicalaccess/logs.hpp>
 
 #include "axesstmclegicreaderunit.hpp"
 

--- a/plugins/pluginsreaderproviders/axesstmclegic/axesstmclegicreaderunit.cpp
+++ b/plugins/pluginsreaderproviders/axesstmclegic/axesstmclegicreaderunit.cpp
@@ -16,6 +16,8 @@
 #include "readercardadapters/axesstmclegicreadercardadapter.hpp"
 #include <boost/filesystem.hpp>
 #include "readercardadapters/axesstmclegicdatatransport.hpp"
+#include <boost/property_tree/xml_parser.hpp>
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/axesstmclegic/axesstmclegicreaderunitconfiguration.cpp
+++ b/plugins/pluginsreaderproviders/axesstmclegic/axesstmclegicreaderunitconfiguration.cpp
@@ -4,6 +4,7 @@
  * \brief  AxessTMCLegic reader unit configuration.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "axesstmclegicreaderunitconfiguration.hpp"
 #include "axesstmclegicreaderprovider.hpp"
 

--- a/plugins/pluginsreaderproviders/axesstmclegic/readercardadapters/axesstmclegicdatatransport.hpp
+++ b/plugins/pluginsreaderproviders/axesstmclegic/readercardadapters/axesstmclegicdatatransport.hpp
@@ -12,6 +12,7 @@
 
 #include <string>
 #include <vector>
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/axesstmclegic/readercardadapters/axesstmclegicreadercardadapter.cpp
+++ b/plugins/pluginsreaderproviders/axesstmclegic/readercardadapters/axesstmclegicreadercardadapter.cpp
@@ -4,6 +4,7 @@
  * \brief AxessTMCLegic reader/card adapter.
  */
 
+#include <logicalaccess/logs.hpp>
 #include "axesstmclegicreadercardadapter.hpp"
 #include "logicalaccess/bufferhelper.hpp"
 

--- a/plugins/pluginsreaderproviders/deister/deisterreaderprovider.cpp
+++ b/plugins/pluginsreaderproviders/deister/deisterreaderprovider.cpp
@@ -6,6 +6,7 @@
 
 #include "deisterreaderprovider.hpp"
 #include "logicalaccess/readerproviders/serialportdatatransport.hpp"
+#include "logicalaccess/myexception.hpp"
 
 #ifdef __unix__
 #include <stdlib.h>
@@ -14,6 +15,7 @@
 
 #include <sstream>
 #include <iomanip>
+#include <logicalaccess/logs.hpp>
 
 #include "deisterreaderunit.hpp"
 

--- a/plugins/pluginsreaderproviders/deister/deisterreaderunit.cpp
+++ b/plugins/pluginsreaderproviders/deister/deisterreaderunit.cpp
@@ -16,6 +16,8 @@
 #include "readercardadapters/deisterreadercardadapter.hpp"
 #include <boost/filesystem.hpp>
 #include "readercardadapters/deisterdatatransport.hpp"
+#include "logicalaccess/myexception.hpp"
+#include <boost/property_tree/xml_parser.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/deister/deisterreaderunitconfiguration.cpp
+++ b/plugins/pluginsreaderproviders/deister/deisterreaderunitconfiguration.cpp
@@ -4,6 +4,7 @@
  * \brief Deister reader unit configuration.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "deisterreaderunitconfiguration.hpp"
 #include "deisterreaderprovider.hpp"
 

--- a/plugins/pluginsreaderproviders/deister/readercardadapters/deisterdatatransport.hpp
+++ b/plugins/pluginsreaderproviders/deister/readercardadapters/deisterdatatransport.hpp
@@ -12,6 +12,7 @@
 
 #include <string>
 #include <vector>
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/deister/readercardadapters/deisterreadercardadapter.cpp
+++ b/plugins/pluginsreaderproviders/deister/readercardadapters/deisterreadercardadapter.cpp
@@ -4,6 +4,7 @@
  * \brief Deister reader/card adapter.
  */
 
+#include <logicalaccess/logs.hpp>
 #include "deisterreadercardadapter.hpp"
 #include "logicalaccess/crypto/tomcrypt.h"
 

--- a/plugins/pluginsreaderproviders/elatec/elatecreaderprovider.cpp
+++ b/plugins/pluginsreaderproviders/elatec/elatecreaderprovider.cpp
@@ -6,6 +6,7 @@
 
 #include "elatecreaderprovider.hpp"
 #include "logicalaccess/readerproviders/serialportdatatransport.hpp"
+#include "logicalaccess/myexception.hpp"
 
 #ifdef __unix__
 #include <stdlib.h>
@@ -14,6 +15,7 @@
 
 #include <sstream>
 #include <iomanip>
+#include <logicalaccess/logs.hpp>
 
 #include "elatecreaderunit.hpp"
 

--- a/plugins/pluginsreaderproviders/elatec/elatecreaderunit.cpp
+++ b/plugins/pluginsreaderproviders/elatec/elatecreaderunit.cpp
@@ -17,6 +17,7 @@
 #include <boost/filesystem.hpp>
 #include "readercardadapters/elatecdatatransport.hpp"
 #include "readercardadapters/elatecbufferparser.hpp"
+#include <boost/property_tree/xml_parser.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/elatec/elatecreaderunitconfiguration.cpp
+++ b/plugins/pluginsreaderproviders/elatec/elatecreaderunitconfiguration.cpp
@@ -4,6 +4,7 @@
  * \brief  Elatec reader unit configuration.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "elatecreaderunitconfiguration.hpp"
 #include "elatecreaderprovider.hpp"
 

--- a/plugins/pluginsreaderproviders/elatec/libraryentry.cpp
+++ b/plugins/pluginsreaderproviders/elatec/libraryentry.cpp
@@ -2,17 +2,7 @@
 #include <memory>
 #include "logicalaccess/readerproviders/readerprovider.hpp"
 #include "elatecreaderprovider.hpp"
-
-#ifdef _MSC_VER
-#include "logicalaccess/msliblogicalaccess.h"
-#else
-#ifndef LIBLOGICALACCESS_API
-#define LIBLOGICALACCESS_API
-#endif
-#ifndef DISABLE_PRAGMA_WARNING
-#define DISABLE_PRAGMA_WARNING /**< \brief winsmcrd.h was modified to support this macro, to avoid MSVC specific warnings pragma */
-#endif
-#endif
+#include "logicalaccess/logicalaccess_api.hpp"
 
 extern "C"
 {

--- a/plugins/pluginsreaderproviders/elatec/readercardadapters/elatecdatatransport.hpp
+++ b/plugins/pluginsreaderproviders/elatec/readercardadapters/elatecdatatransport.hpp
@@ -12,6 +12,7 @@
 
 #include <string>
 #include <vector>
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/gunnebo/gunneboreaderprovider.cpp
+++ b/plugins/pluginsreaderproviders/gunnebo/gunneboreaderprovider.cpp
@@ -6,6 +6,7 @@
 
 #include "gunneboreaderprovider.hpp"
 #include "logicalaccess/readerproviders/serialportdatatransport.hpp"
+#include "logicalaccess/myexception.hpp"
 
 #ifdef __unix__
 #include <stdlib.h>

--- a/plugins/pluginsreaderproviders/gunnebo/gunneboreaderunit.cpp
+++ b/plugins/pluginsreaderproviders/gunnebo/gunneboreaderunit.cpp
@@ -15,9 +15,12 @@
 #include "logicalaccess/cards/chip.hpp"
 #include "readercardadapters/gunneboreadercardadapter.hpp"
 #include <boost/filesystem.hpp>
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/dynlibrary/librarymanager.hpp"
 #include "logicalaccess/dynlibrary/idynlibrary.hpp"
 #include "logicalaccess/readerproviders/serialportdatatransport.hpp"
+#include "logicalaccess/settings.hpp"
+#include <boost/property_tree/xml_parser.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/gunnebo/gunneboreaderunitconfiguration.cpp
+++ b/plugins/pluginsreaderproviders/gunnebo/gunneboreaderunitconfiguration.cpp
@@ -4,6 +4,7 @@
  * \brief  Gunnebo reader unit configuration.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "gunneboreaderunitconfiguration.hpp"
 #include "gunneboreaderprovider.hpp"
 

--- a/plugins/pluginsreaderproviders/gunnebo/libraryentry.cpp
+++ b/plugins/pluginsreaderproviders/gunnebo/libraryentry.cpp
@@ -2,17 +2,7 @@
 #include <memory>
 #include "logicalaccess/readerproviders/readerprovider.hpp"
 #include "gunneboreaderprovider.hpp"
-
-#ifdef _MSC_VER
-#include "logicalaccess/msliblogicalaccess.h"
-#else
-#ifndef LIBLOGICALACCESS_API
-#define LIBLOGICALACCESS_API
-#endif
-#ifndef DISABLE_PRAGMA_WARNING
-#define DISABLE_PRAGMA_WARNING /**< \brief winsmcrd.h was modified to support this macro, to avoid MSVC specific warnings pragma */
-#endif
-#endif
+#include "logicalaccess/logicalaccess_api.hpp"
 
 extern "C"
 {

--- a/plugins/pluginsreaderproviders/idondemand/idondemandreaderprovider.cpp
+++ b/plugins/pluginsreaderproviders/idondemand/idondemandreaderprovider.cpp
@@ -6,6 +6,7 @@
 
 #include "idondemandreaderprovider.hpp"
 #include "logicalaccess/readerproviders/serialportdatatransport.hpp"
+#include "logicalaccess/myexception.hpp"
 
 #ifdef __unix__
 #include <stdlib.h>
@@ -14,6 +15,7 @@
 
 #include <sstream>
 #include <iomanip>
+#include <logicalaccess/logs.hpp>
 
 #include "idondemandreaderunit.hpp"
 

--- a/plugins/pluginsreaderproviders/idondemand/idondemandreaderunit.cpp
+++ b/plugins/pluginsreaderproviders/idondemand/idondemandreaderunit.cpp
@@ -17,8 +17,11 @@
 #include "generictagidondemandchip.hpp"
 #include "commands/generictagidondemandaccesscontrolcardservice.hpp"
 #include <boost/filesystem.hpp>
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/readerproviders/serialportdatatransport.hpp"
 #include "commands/generictagidondemandcommands.hpp"
+#include "logicalaccess/myexception.hpp"
+#include <boost/property_tree/xml_parser.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/idondemand/idondemandreaderunitconfiguration.cpp
+++ b/plugins/pluginsreaderproviders/idondemand/idondemandreaderunitconfiguration.cpp
@@ -4,6 +4,8 @@
  * \brief  IdOnDemand reader unit configuration.
  */
 
+#include <boost/property_tree/ptree.hpp>
+#include <logicalaccess/logs.hpp>
 #include "idondemandreaderunitconfiguration.hpp"
 #include "idondemandreaderprovider.hpp"
 

--- a/plugins/pluginsreaderproviders/idondemand/libraryentry.cpp
+++ b/plugins/pluginsreaderproviders/idondemand/libraryentry.cpp
@@ -2,17 +2,7 @@
 #include <memory>
 #include "logicalaccess/readerproviders/readerprovider.hpp"
 #include "idondemandreaderprovider.hpp"
-
-#ifdef _MSC_VER
-#include "logicalaccess/msliblogicalaccess.h"
-#else
-#ifndef LIBLOGICALACCESS_API
-#define LIBLOGICALACCESS_API
-#endif
-#ifndef DISABLE_PRAGMA_WARNING
-#define DISABLE_PRAGMA_WARNING /**< \brief winsmcrd.h was modified to support this macro, to avoid MSVC specific warnings pragma */
-#endif
-#endif
+#include "logicalaccess/logicalaccess_api.hpp"
 
 extern "C"
 {

--- a/plugins/pluginsreaderproviders/idondemand/readercardadapters/idondemandreadercardadapter.cpp
+++ b/plugins/pluginsreaderproviders/idondemand/readercardadapters/idondemandreadercardadapter.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "idondemandreadercardadapter.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/iso7816/commands/desfireev1iso7816commands.cpp
+++ b/plugins/pluginsreaderproviders/iso7816/commands/desfireev1iso7816commands.cpp
@@ -18,6 +18,7 @@
 #include "logicalaccess/cards/samkeystorage.hpp"
 #include "samcommands.hpp"
 #include "nxpav2keydiversification.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {
@@ -47,9 +48,9 @@ namespace logicalaccess
         return freemem;
     }
 
-    vector<DFName> DESFireEV1ISO7816Commands::getDFNames()
+    std::vector<DFName> DESFireEV1ISO7816Commands::getDFNames()
     {
-        vector<DFName> dfnames;
+        std::vector<DFName> dfnames;
         unsigned char err;
         unsigned char cmd = DFEV1_INS_GET_DF_NAMES;
 
@@ -71,9 +72,9 @@ namespace logicalaccess
         return dfnames;
     }
 
-    vector<unsigned short> DESFireEV1ISO7816Commands::getISOFileIDs()
+    std::vector<unsigned short> DESFireEV1ISO7816Commands::getISOFileIDs()
     {
-        vector<unsigned short> fileids;
+        std::vector<unsigned short> fileids;
         unsigned char err;
         unsigned char cmd = DFEV1_INS_GET_ISO_FILE_IDS;
         std::vector<unsigned char> fullr;

--- a/plugins/pluginsreaderproviders/iso7816/commands/desfireev1iso7816commands.hpp
+++ b/plugins/pluginsreaderproviders/iso7816/commands/desfireev1iso7816commands.hpp
@@ -44,13 +44,13 @@ namespace logicalaccess
          * \brief Get the ISO DF-Names of all active application.
          * \return The DF-Names list.
          */
-        virtual vector<DFName> getDFNames();
+        virtual std::vector<DFName> getDFNames();
 
         /**
          * \brief Get the ISO FID of all active files within the currently selected application.
          * \return The ISO FID list.
          */
-        virtual vector<unsigned short> getISOFileIDs();
+        virtual std::vector<unsigned short> getISOFileIDs();
 
         /**
          * \brief Create a new application.

--- a/plugins/pluginsreaderproviders/iso7816/commands/desfireiso7816commands.cpp
+++ b/plugins/pluginsreaderproviders/iso7816/commands/desfireiso7816commands.cpp
@@ -11,6 +11,7 @@
 #include "nxpkeydiversification.hpp"
 #include "nxpav1keydiversification.hpp"
 #include "nxpav2keydiversification.hpp"
+#include "logicalaccess/myexception.hpp"
 
 #include <cstring>
 

--- a/plugins/pluginsreaderproviders/iso7816/commands/samiso7816commands.hpp
+++ b/plugins/pluginsreaderproviders/iso7816/commands/samiso7816commands.hpp
@@ -31,6 +31,8 @@
 #include <vector>
 #include <iostream>
 
+#include "logicalaccess/myexception.hpp"
+
 #define DEFAULT_SAM_CLA 0x80
 
 namespace logicalaccess

--- a/plugins/pluginsreaderproviders/iso7816/iso7816readerunitconfiguration.cpp
+++ b/plugins/pluginsreaderproviders/iso7816/iso7816readerunitconfiguration.cpp
@@ -4,6 +4,8 @@
  * \brief PC/SC reader unit configuration.
  */
 
+#include <boost/property_tree/ptree.hpp>
+#include <logicalaccess/logs.hpp>
 #include "iso7816readerunitconfiguration.hpp"
 #include "iso7816readerunit.hpp"
 #include "desfirekey.hpp"

--- a/plugins/pluginsreaderproviders/iso7816/libraryentry.cpp
+++ b/plugins/pluginsreaderproviders/iso7816/libraryentry.cpp
@@ -4,18 +4,7 @@
 #include "commands/twiciso7816commands.hpp"
 #include "commands/desfireiso7816commands.hpp"
 #include "commands/desfireev1iso7816commands.hpp"
-#include "logicalaccess/cards/chip.hpp"
-
-#ifdef _MSC_VER
-#include "logicalaccess/msliblogicalaccess.h"
-#else
-#ifndef LIBLOGICALACCESS_API
-#define LIBLOGICALACCESS_API
-#endif
-#ifndef DISABLE_PRAGMA_WARNING
-#define DISABLE_PRAGMA_WARNING /**< \brief winsmcrd.h was modified to support this macro, to avoid MSVC specific warnings pragma */
-#endif
-#endif
+#include "logicalaccess/logicalaccess_api.hpp"
 
 extern "C"
 {

--- a/plugins/pluginsreaderproviders/keyboard/keyboardreaderprovider.cpp
+++ b/plugins/pluginsreaderproviders/keyboard/keyboardreaderprovider.cpp
@@ -10,6 +10,9 @@
 #include <iomanip>
 #include <codecvt>
 
+#include <chrono>
+#include <thread>
+
 #ifdef _WINDOWS
 EXTERN_C IMAGE_DOS_HEADER __ImageBase;
 #include <Userenv.h>

--- a/plugins/pluginsreaderproviders/keyboard/keyboardreaderunit.cpp
+++ b/plugins/pluginsreaderproviders/keyboard/keyboardreaderunit.cpp
@@ -14,6 +14,8 @@
 #include "logicalaccess/cards/chip.hpp"
 #include <boost/filesystem.hpp>
 #include "logicalaccess/bufferhelper.hpp"
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/keyboard/keyboardreaderunitconfiguration.cpp
+++ b/plugins/pluginsreaderproviders/keyboard/keyboardreaderunitconfiguration.cpp
@@ -6,6 +6,7 @@
 
 #include "keyboardreaderunitconfiguration.hpp"
 #include "keyboardreaderprovider.hpp"
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/keyboard/libraryentry.cpp
+++ b/plugins/pluginsreaderproviders/keyboard/libraryentry.cpp
@@ -2,17 +2,7 @@
 #include <memory>
 #include "logicalaccess/readerproviders/readerprovider.hpp"
 #include "keyboardreaderprovider.hpp"
-
-#ifdef _MSC_VER
-#include "logicalaccess/msliblogicalaccess.h"
-#else
-#ifndef LIBLOGICALACCESS_API
-#define LIBLOGICALACCESS_API
-#endif
-#ifndef DISABLE_PRAGMA_WARNING
-#define DISABLE_PRAGMA_WARNING /**< \brief winsmcrd.h was modified to support this macro, to avoid MSVC specific warnings pragma */
-#endif
-#endif
+#include "logicalaccess/logicalaccess_api.hpp"
 
 extern "C"
 {

--- a/plugins/pluginsreaderproviders/ok5553/commands/mifareok5553commands.cpp
+++ b/plugins/pluginsreaderproviders/ok5553/commands/mifareok5553commands.cpp
@@ -14,6 +14,7 @@
 #include "logicalaccess/cards/computermemorykeystorage.hpp"
 #include "logicalaccess/cards/readermemorykeystorage.hpp"
 #include "logicalaccess/cards/samkeystorage.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/ok5553/libraryentry.cpp
+++ b/plugins/pluginsreaderproviders/ok5553/libraryentry.cpp
@@ -2,17 +2,7 @@
 #include <memory>
 #include "logicalaccess/readerproviders/readerprovider.hpp"
 #include "ok5553readerprovider.hpp"
-
-#ifdef _MSC_VER
-#include "logicalaccess/msliblogicalaccess.h"
-#else
-#ifndef LIBLOGICALACCESS_API
-#define LIBLOGICALACCESS_API
-#endif
-#ifndef DISABLE_PRAGMA_WARNING
-#define DISABLE_PRAGMA_WARNING /**< \brief winsmcrd.h was modified to support this macro, to avoid MSVC specific warnings pragma */
-#endif
-#endif
+#include "logicalaccess/logicalaccess_api.hpp"
 
 extern "C"
 {

--- a/plugins/pluginsreaderproviders/ok5553/ok5553readerprovider.cpp
+++ b/plugins/pluginsreaderproviders/ok5553/ok5553readerprovider.cpp
@@ -16,6 +16,7 @@
 
 #include "ok5553readerunit.hpp"
 #include "logicalaccess/readerproviders/serialportdatatransport.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/ok5553/ok5553readerunit.cpp
+++ b/plugins/pluginsreaderproviders/ok5553/ok5553readerunit.cpp
@@ -23,6 +23,8 @@
 #include "commands/mifareok5553commands.hpp"
 #include "commands/mifareultralightok5553commands.hpp"
 #include <boost/filesystem.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
 #include "logicalaccess/readerproviders/serialportdatatransport.hpp"
 
 namespace logicalaccess

--- a/plugins/pluginsreaderproviders/ok5553/ok5553readerunitconfiguration.cpp
+++ b/plugins/pluginsreaderproviders/ok5553/ok5553readerunitconfiguration.cpp
@@ -4,6 +4,7 @@
  * \brief  OK5553 reader unit configuration.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "ok5553readerunitconfiguration.hpp"
 #include "ok5553readerprovider.hpp"
 

--- a/plugins/pluginsreaderproviders/ok5553/readercardadapters/ok5553readercardadapter.cpp
+++ b/plugins/pluginsreaderproviders/ok5553/readercardadapters/ok5553readercardadapter.cpp
@@ -6,6 +6,7 @@
 
 #include "ok5553readercardadapter.hpp"
 #include "logicalaccess/bufferhelper.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/pcsc/commands/iso15693pcsccommands.cpp
+++ b/plugins/pluginsreaderproviders/pcsc/commands/iso15693pcsccommands.cpp
@@ -11,6 +11,7 @@
 #include <sstream>
 
 #include "iso15693chip.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/pcsc/commands/mifarepcsccommands.cpp
+++ b/plugins/pluginsreaderproviders/pcsc/commands/mifarepcsccommands.cpp
@@ -15,6 +15,7 @@
 #include "logicalaccess/cards/computermemorykeystorage.hpp"
 #include "logicalaccess/cards/readermemorykeystorage.hpp"
 #include "logicalaccess/cards/samkeystorage.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/pcsc/commands/mifareplusspringcardcommands.cpp
+++ b/plugins/pluginsreaderproviders/pcsc/commands/mifareplusspringcardcommands.cpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <iomanip>
 #include <sstream>
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/pcsc/commands/mifareplusspringcardcommandssl1.cpp
+++ b/plugins/pluginsreaderproviders/pcsc/commands/mifareplusspringcardcommandssl1.cpp
@@ -7,6 +7,7 @@
 #include "mifareplusspringcardcommandssl1.hpp"
 #include "../pcscreaderprovider.hpp"
 #include "mifarepluschip.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/pcsc/commands/mifareplusspringcardcommandssl3.cpp
+++ b/plugins/pluginsreaderproviders/pcsc/commands/mifareplusspringcardcommandssl3.cpp
@@ -10,6 +10,7 @@
 
 #include "../pcscreaderprovider.hpp"
 #include "mifarepluschip.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/pcsc/commands/mifareultralightcpcsccommands.cpp
+++ b/plugins/pluginsreaderproviders/pcsc/commands/mifareultralightcpcsccommands.cpp
@@ -21,6 +21,7 @@
 #include "logicalaccess/crypto/des_cipher.hpp"
 #include "logicalaccess/crypto/des_symmetric_key.hpp"
 #include "logicalaccess/crypto/des_initialization_vector.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/pcsc/libraryentry.cpp
+++ b/plugins/pluginsreaderproviders/pcsc/libraryentry.cpp
@@ -8,17 +8,7 @@
 #include "readers/springcardreaderunit.hpp"
 #include "readers/cherryreaderunit.hpp"
 #include "readers/acsacrreaderunit.hpp"
-
-#ifdef _MSC_VER
-#include "logicalaccess/msliblogicalaccess.h"
-#else
-#ifndef LIBLOGICALACCESS_API
-#define LIBLOGICALACCESS_API
-#endif
-#ifndef DISABLE_PRAGMA_WARNING
-#define DISABLE_PRAGMA_WARNING /**< \brief winsmcrd.h was modified to support this macro, to avoid MSVC specific warnings pragma */
-#endif
-#endif
+#include "logicalaccess/logicalaccess_api.hpp"
 
 extern "C"
 {

--- a/plugins/pluginsreaderproviders/pcsc/pcsc_fwd.hpp
+++ b/plugins/pluginsreaderproviders/pcsc/pcsc_fwd.hpp
@@ -1,0 +1,14 @@
+//
+// Created by xaqq on 6/24/15.
+//
+
+#ifndef LIBLOGICALACCESS_PCSC_FWD_HPP
+#define LIBLOGICALACCESS_PCSC_FWD_HPP
+
+namespace logicalaccess
+{
+    class PCSCReaderCardAdapter;
+    class PCSCReaderProvider;
+}
+
+#endif //LIBLOGICALACCESS_PCSC_FWD_HPP

--- a/plugins/pluginsreaderproviders/pcsc/pcscdatatransport.cpp
+++ b/plugins/pluginsreaderproviders/pcsc/pcscdatatransport.cpp
@@ -11,6 +11,9 @@
 #include <boost/foreach.hpp>
 #include <boost/optional.hpp>
 #include <boost/array.hpp>
+#include <logicalaccess/logs.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/pcsc/pcscreaderprovider.cpp
+++ b/plugins/pluginsreaderproviders/pcsc/pcscreaderprovider.cpp
@@ -16,6 +16,7 @@
 #include <iomanip>
 
 #include "pcscreaderunit.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/pcsc/pcscreaderunit.cpp
+++ b/plugins/pluginsreaderproviders/pcsc/pcscreaderunit.cpp
@@ -9,6 +9,7 @@
 #include <iostream>
 #include <iomanip>
 #include <sstream>
+#include <thread>
 
 #include "pcscreaderprovider.hpp"
 #include "logicalaccess/services/accesscontrol/cardsformatcomposite.hpp"
@@ -61,9 +62,14 @@
 #include <boost/filesystem.hpp>
 #include <memory>
 
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
+
 #ifdef UNIX
 #include <sys/time.h>
 #endif
+
+#include "logicalaccess/settings.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/pcsc/pcscreaderunit.hpp
+++ b/plugins/pluginsreaderproviders/pcsc/pcscreaderunit.hpp
@@ -7,16 +7,13 @@
 #ifndef LOGICALACCESS_PCSCREADERUNIT_HPP
 #define LOGICALACCESS_PCSCREADERUNIT_HPP
 
-#include "logicalaccess/readerproviders/readerunit.hpp"
 #include "pcscreaderunitconfiguration.hpp"
 #include "../iso7816/iso7816readerunit.hpp"
-#include "logicalaccess/cards/readermemorykeystorage.hpp"
+#include "pcsc_fwd.hpp"
 
 namespace logicalaccess
 {
     class Chip;
-    class PCSCReaderCardAdapter;
-    class PCSCReaderProvider;
     class SAMChip;
 
     /**

--- a/plugins/pluginsreaderproviders/pcsc/pcscreaderunitconfiguration.cpp
+++ b/plugins/pluginsreaderproviders/pcsc/pcscreaderunitconfiguration.cpp
@@ -4,6 +4,7 @@
  * \brief PC/SC reader unit configuration.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "pcscreaderunitconfiguration.hpp"
 #include "pcscreaderprovider.hpp"
 #include "pcscreaderunit.hpp"

--- a/plugins/pluginsreaderproviders/pcsc/readers/omnikey5427readerunitconfiguration.cpp
+++ b/plugins/pluginsreaderproviders/pcsc/readers/omnikey5427readerunitconfiguration.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <logicalaccess/cards/tripledeskey.hpp>
+#include <boost/property_tree/ptree.hpp>
 #include "omnikey5427readerunitconfiguration.hpp"
 
 using namespace logicalaccess;

--- a/plugins/pluginsreaderproviders/pcsc/readers/omnikeylanxx21readerunit.cpp
+++ b/plugins/pluginsreaderproviders/pcsc/readers/omnikeylanxx21readerunit.cpp
@@ -7,6 +7,9 @@
 #include "../readers/omnikeylanxx21readerunit.hpp"
 #include "../pcscreaderprovider.hpp"
 
+#include "logicalaccess/myexception.hpp"
+#include <thread>
+
 #include <iostream>
 #include <iomanip>
 #include <sstream>

--- a/plugins/pluginsreaderproviders/pcsc/readers/omnikeyxx21readerunitconfiguration.cpp
+++ b/plugins/pluginsreaderproviders/pcsc/readers/omnikeyxx21readerunitconfiguration.cpp
@@ -4,6 +4,7 @@
  * \brief Omnikey XX21 reader unit configuration.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "../readers/omnikeyxx21readerunitconfiguration.hpp"
 
 namespace logicalaccess

--- a/plugins/pluginsreaderproviders/promag/libraryentry.cpp
+++ b/plugins/pluginsreaderproviders/promag/libraryentry.cpp
@@ -2,17 +2,7 @@
 #include <memory>
 #include "logicalaccess/readerproviders/readerprovider.hpp"
 #include "promagreaderprovider.hpp"
-
-#ifdef _MSC_VER
-#include "logicalaccess/msliblogicalaccess.h"
-#else
-#ifndef LIBLOGICALACCESS_API
-#define LIBLOGICALACCESS_API
-#endif
-#ifndef DISABLE_PRAGMA_WARNING
-#define DISABLE_PRAGMA_WARNING /**< \brief winsmcrd.h was modified to support this macro, to avoid MSVC specific warnings pragma */
-#endif
-#endif
+#include "logicalaccess/logicalaccess_api.hpp"
 
 extern "C"
 {

--- a/plugins/pluginsreaderproviders/promag/promagreaderprovider.cpp
+++ b/plugins/pluginsreaderproviders/promag/promagreaderprovider.cpp
@@ -6,6 +6,7 @@
 
 #include "promagreaderprovider.hpp"
 #include "logicalaccess/readerproviders/serialportdatatransport.hpp"
+#include "logicalaccess/myexception.hpp"
 
 #ifdef __unix__
 #include <stdlib.h>

--- a/plugins/pluginsreaderproviders/promag/promagreaderunit.cpp
+++ b/plugins/pluginsreaderproviders/promag/promagreaderunit.cpp
@@ -16,6 +16,8 @@
 #include "readercardadapters/promagreadercardadapter.hpp"
 #include <boost/filesystem.hpp>
 #include "readercardadapters/promagdatatransport.hpp"
+#include "logicalaccess/bufferhelper.hpp"
+#include <boost/property_tree/xml_parser.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/promag/promagreaderunitconfiguration.cpp
+++ b/plugins/pluginsreaderproviders/promag/promagreaderunitconfiguration.cpp
@@ -4,6 +4,7 @@
  * \brief  Promag reader unit configuration.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "promagreaderunitconfiguration.hpp"
 #include "promagreaderprovider.hpp"
 

--- a/plugins/pluginsreaderproviders/promag/readercardadapters/promagbufferparser.cpp
+++ b/plugins/pluginsreaderproviders/promag/readercardadapters/promagbufferparser.cpp
@@ -4,6 +4,7 @@
  * \brief Promag buffer parser.
  */
 
+#include <logicalaccess/logs.hpp>
 #include "promagbufferparser.hpp"
 #include "promagreadercardadapter.hpp"
 

--- a/plugins/pluginsreaderproviders/promag/readercardadapters/promagdatatransport.hpp
+++ b/plugins/pluginsreaderproviders/promag/readercardadapters/promagdatatransport.hpp
@@ -12,6 +12,7 @@
 
 #include <string>
 #include <vector>
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/rfideas/libraryentry.cpp
+++ b/plugins/pluginsreaderproviders/rfideas/libraryentry.cpp
@@ -2,17 +2,7 @@
 #include <memory>
 #include "logicalaccess/readerproviders/readerprovider.hpp"
 #include "rfideasreaderprovider.hpp"
-
-#ifdef _MSC_VER
-#include "logicalaccess/msliblogicalaccess.h"
-#else
-#ifndef LIBLOGICALACCESS_API
-#define LIBLOGICALACCESS_API
-#endif
-#ifndef DISABLE_PRAGMA_WARNING
-#define DISABLE_PRAGMA_WARNING /**< \brief winsmcrd.h was modified to support this macro, to avoid MSVC specific warnings pragma */
-#endif
-#endif
+#include "logicalaccess/logicalaccess_api.hpp"
 
 extern "C"
 {

--- a/plugins/pluginsreaderproviders/rfideas/rfideasreaderunit.cpp
+++ b/plugins/pluginsreaderproviders/rfideas/rfideasreaderunit.cpp
@@ -10,13 +10,19 @@
 #include <iostream>
 #include <iomanip>
 #include <sstream>
+#include <thread>
+#include <chrono>
 
 #include "rfideasreaderprovider.hpp"
 #include "logicalaccess/services/accesscontrol/cardsformatcomposite.hpp"
 #include "logicalaccess/cards/chip.hpp"
 #include <boost/filesystem.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
 #include "logicalaccess/dynlibrary/librarymanager.hpp"
 #include "logicalaccess/dynlibrary/idynlibrary.hpp"
+#include "logicalaccess/logs.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/rfideas/rfideasreaderunitconfiguration.cpp
+++ b/plugins/pluginsreaderproviders/rfideas/rfideasreaderunitconfiguration.cpp
@@ -6,6 +6,7 @@
 
 #include "rfideasreaderunitconfiguration.hpp"
 #include "rfideasreaderprovider.hpp"
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/rpleth/libraryentry.cpp
+++ b/plugins/pluginsreaderproviders/rpleth/libraryentry.cpp
@@ -2,17 +2,7 @@
 #include <memory>
 #include "logicalaccess/readerproviders/readerprovider.hpp"
 #include "rplethreaderprovider.hpp"
-
-#ifdef _MSC_VER
-#include "logicalaccess/msliblogicalaccess.h"
-#else
-#ifndef LIBLOGICALACCESS_API
-#define LIBLOGICALACCESS_API
-#endif
-#ifndef DISABLE_PRAGMA_WARNING
-#define DISABLE_PRAGMA_WARNING /**< \brief winsmcrd.h was modified to support this macro, to avoid MSVC specific warnings pragma */
-#endif
-#endif
+#include "logicalaccess/logicalaccess_api.hpp"
 
 extern "C"
 {

--- a/plugins/pluginsreaderproviders/rpleth/rpleth_fwd.hpp
+++ b/plugins/pluginsreaderproviders/rpleth/rpleth_fwd.hpp
@@ -1,0 +1,79 @@
+//
+// Created by xaqq on 6/24/15.
+//
+
+#ifndef LIBLOGICALACCESS_RPLETH_FWD_HPP
+#define LIBLOGICALACCESS_RPLETH_FWD_HPP
+
+namespace logicalaccess
+{
+    class RplethReaderCardAdapter;
+    class RplethLEDBuzzerDisplay;
+    class RplethReaderUnitConfiguration;
+    class RplethReaderProvider;
+
+    /**
+   * \brief Device code in Rpleth protocol.
+   */
+    typedef enum
+    {
+        RPLETH = 0x00,
+        HID = 0X01,
+        LCD = 0x02
+    } Device;
+
+    /**
+     * \brief RplethCommand code in Rpleth protocol.
+     */
+    typedef enum
+    {
+        STATEDHCP = 0x01,
+        DHCP = 0x02,
+        MAC = 0x03,
+        IP = 0x04,
+        SUBNET = 0x05,
+        GATEWAY = 0x06,
+        PORT = 0x07,
+        MESSAGE = 0x08,
+        RESET = 0x09,
+        PING = 0x0a,
+        SET_CONTEXT = 0x0b
+    } RplethCommand;
+
+    /**
+     * \brief HidCommand code in Rpleth protocol.
+     */
+    typedef enum
+    {
+        BEEP = 0x00,
+        GREENLED = 0x01,
+        REDLED = 0x02,
+        NOP = 0x03,
+        BADGE = 0x04,
+        COM = 0x05,
+        WAIT_INSERTION = 0x06,
+        WAIT_REMOVAL = 0x07,
+        CONNECT = 0x08,
+        DISCONNECT = 0x09,
+        GET_READERTYPE = 0x0A,
+        GET_CSN = 0x0B,
+        SET_CARDTYPE = 0x0C,
+        SEND_CARDS = 0x0D,
+        RECEIVE_UNPRESENTED_CARDS = 0x0E
+    } HidCommand;
+
+    /**
+     * \brief LcdCommand code in Rpleth protocol.
+     */
+    typedef enum
+    {
+        DISPLAY = 0x00,
+        DISPLAYT = 0X01,
+        BLINK = 0X02,
+        SCROLL = 0X03,
+        DISPLAYTIME = 0x04
+    } LcdCommand;
+
+}
+
+#endif //LIBLOGICALACCESS_RPLETH_FWD_HPP

--- a/plugins/pluginsreaderproviders/rpleth/rplethdatatransport.cpp
+++ b/plugins/pluginsreaderproviders/rpleth/rplethdatatransport.cpp
@@ -14,6 +14,9 @@
 #include <boost/array.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <ctime>
+#include <chrono>
+#include <logicalaccess/logs.hpp>
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/rpleth/rplethlcddisplay.cpp
+++ b/plugins/pluginsreaderproviders/rpleth/rplethlcddisplay.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "rplethlcddisplay.hpp"
+#include "readercardadapters/rplethreadercardadapter.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/rpleth/rplethledbuzzerdisplay.cpp
+++ b/plugins/pluginsreaderproviders/rpleth/rplethledbuzzerdisplay.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "rplethledbuzzerdisplay.hpp"
+#include "readercardadapters/rplethreadercardadapter.hpp"
 
 #include <iostream>
 #include <iomanip>
@@ -53,4 +54,7 @@ namespace logicalaccess
         command.push_back(static_cast<unsigned char>(status));
         getRplethReaderCardAdapter()->sendRplethCommand(command, false);
     }
+
+    std::shared_ptr<RplethReaderCardAdapter> RplethLEDBuzzerDisplay::getRplethReaderCardAdapter()
+    { return std::dynamic_pointer_cast<RplethReaderCardAdapter>(getReaderCardAdapter()); }
 }

--- a/plugins/pluginsreaderproviders/rpleth/rplethledbuzzerdisplay.hpp
+++ b/plugins/pluginsreaderproviders/rpleth/rplethledbuzzerdisplay.hpp
@@ -7,12 +7,10 @@
 #ifndef D3L_PCSC_RPLETHLEDBUZZERDISPLAY_HPP
 #define D3L_PCSC_RPLETHLEDBUZZERDISPLAY_HPP
 
-#include "readercardadapters/rplethreadercardadapter.hpp"
-
 #include <string>
 #include <vector>
-
-#include "logicalaccess/logs.hpp"
+#include <logicalaccess/readerproviders/ledbuzzerdisplay.hpp>
+#include "rpleth_fwd.hpp"
 
 namespace logicalaccess
 {
@@ -52,11 +50,7 @@ namespace logicalaccess
          */
         void setLED(HidCommand led, bool status);
 
-        /**
-         * \brief Get the rpleth reader card adapter.
-         * \return The rpleth reader card adapter.
-         */
-        std::shared_ptr<RplethReaderCardAdapter> getRplethReaderCardAdapter() { return std::dynamic_pointer_cast<RplethReaderCardAdapter>(getReaderCardAdapter()); };
+        std::shared_ptr<RplethReaderCardAdapter> getRplethReaderCardAdapter();;
 
     protected:
 

--- a/plugins/pluginsreaderproviders/rpleth/rplethreaderprovider.cpp
+++ b/plugins/pluginsreaderproviders/rpleth/rplethreaderprovider.cpp
@@ -13,6 +13,7 @@
 
 #include <sstream>
 #include <iomanip>
+#include <logicalaccess/logs.hpp>
 
 #include "rplethreaderunit.hpp"
 

--- a/plugins/pluginsreaderproviders/rpleth/rplethreaderprovider.hpp
+++ b/plugins/pluginsreaderproviders/rpleth/rplethreaderprovider.hpp
@@ -8,12 +8,8 @@
 #define LOGICALACCESS_READERRPLETH_PROVIDER_HPP
 
 #include "logicalaccess/readerproviders/readerprovider.hpp"
-#include "rplethreaderunit.hpp"
-
 #include <string>
 #include <vector>
-
-#include "logicalaccess/logs.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/rpleth/rplethreaderunit.cpp
+++ b/plugins/pluginsreaderproviders/rpleth/rplethreaderunit.cpp
@@ -18,12 +18,18 @@
 #include "logicalaccess/services/accesscontrol/cardsformatcomposite.hpp"
 #include "logicalaccess/cards/chip.hpp"
 #include <boost/filesystem.hpp>
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/readerproviders/tcpdatatransport.hpp"
 #include "rplethledbuzzerdisplay.hpp"
 #include "rplethlcddisplay.hpp"
 #include "rplethdatatransport.hpp"
 #include "desfirechip.hpp"
 #include "commands/desfireiso7816commands.hpp"
+
+#include "logicalaccess/readerproviders/serialportxml.hpp"
+#include "rplethreaderunitconfiguration.hpp"
+#include "logicalaccess/myexception.hpp"
+#include <boost/property_tree/xml_parser.hpp>
 
 namespace logicalaccess
 {
@@ -656,4 +662,7 @@ namespace logicalaccess
 
         return rptype;
     }
+
+    std::shared_ptr<RplethReaderUnitConfiguration> RplethReaderUnit::getRplethConfiguration()
+    { return std::dynamic_pointer_cast<RplethReaderUnitConfiguration>(getConfiguration()); }
 }

--- a/plugins/pluginsreaderproviders/rpleth/rplethreaderunit.hpp
+++ b/plugins/pluginsreaderproviders/rpleth/rplethreaderunit.hpp
@@ -8,78 +8,10 @@
 #define LOGICALACCESS_RPLETHREADERUNIT_HPP
 
 #include "logicalaccess/readerproviders/readerunit.hpp"
-#include "logicalaccess/readerproviders/serialportxml.hpp"
-#include "rplethreaderunitconfiguration.hpp"
-#include "readercardadapters/rplethreadercardadapter.hpp"
-#include <boost/asio/ip/tcp.hpp>
+#include "rpleth_fwd.hpp"
 
 namespace logicalaccess
 {
-    class Profile;
-    class RplethReaderCardAdapter;
-    class RplethReaderProvider;
-
-    /**
-     * \brief Device code in Rpleth protocol.
-     */
-    typedef enum
-    {
-        RPLETH = 0x00,
-        HID = 0X01,
-        LCD = 0x02
-    } Device;
-
-    /**
-     * \brief RplethCommand code in Rpleth protocol.
-     */
-    typedef enum
-    {
-        STATEDHCP = 0x01,
-        DHCP = 0x02,
-        MAC = 0x03,
-        IP = 0x04,
-        SUBNET = 0x05,
-        GATEWAY = 0x06,
-        PORT = 0x07,
-        MESSAGE = 0x08,
-        RESET = 0x09,
-        PING = 0x0a,
-		SET_CONTEXT = 0x0b
-    } RplethCommand;
-
-    /**
-     * \brief HidCommand code in Rpleth protocol.
-     */
-    typedef enum
-    {
-        BEEP = 0x00,
-        GREENLED = 0x01,
-        REDLED = 0x02,
-        NOP = 0x03,
-        BADGE = 0x04,
-        COM = 0x05,
-        WAIT_INSERTION = 0x06,
-        WAIT_REMOVAL = 0x07,
-        CONNECT = 0x08,
-        DISCONNECT = 0x09,
-        GET_READERTYPE = 0x0A,
-        GET_CSN = 0x0B,
-        SET_CARDTYPE = 0x0C,
-		SEND_CARDS = 0x0D,
-		RECEIVE_UNPRESENTED_CARDS = 0x0E
-    } HidCommand;
-
-    /**
-     * \brief LcdCommand code in Rpleth protocol.
-     */
-    typedef enum
-    {
-        DISPLAY = 0x00,
-        DISPLAYT = 0X01,
-        BLINK = 0X02,
-        SCROLL = 0X03,
-        DISPLAYTIME = 0x04
-    } LcdCommand;
 
     /**
      * \brief The Rpleth reader unit class.
@@ -215,11 +147,7 @@ namespace logicalaccess
          */
         virtual void unSerialize(boost::property_tree::ptree& node);
 
-        /**
-         * \brief Get the Rpleth reader unit configuration.
-         * \return The Rpleth reader unit configuration.
-         */
-        std::shared_ptr<RplethReaderUnitConfiguration> getRplethConfiguration() { return std::dynamic_pointer_cast<RplethReaderUnitConfiguration>(getConfiguration()); };
+        std::shared_ptr<RplethReaderUnitConfiguration> getRplethConfiguration();;
 
         /**
          * \brief Get the Rpleth reader provider.

--- a/plugins/pluginsreaderproviders/rpleth/rplethreaderunitconfiguration.cpp
+++ b/plugins/pluginsreaderproviders/rpleth/rplethreaderunitconfiguration.cpp
@@ -4,6 +4,7 @@
  * \brief  Rpleth reader unit configuration.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "rplethreaderunitconfiguration.hpp"
 #include "rplethreaderprovider.hpp"
 

--- a/plugins/pluginsreaderproviders/sciel/libraryentry.cpp
+++ b/plugins/pluginsreaderproviders/sciel/libraryentry.cpp
@@ -2,17 +2,7 @@
 #include <memory>
 #include "logicalaccess/readerproviders/readerprovider.hpp"
 #include "scielreaderprovider.hpp"
-
-#ifdef _MSC_VER
-#include "logicalaccess/msliblogicalaccess.h"
-#else
-#ifndef LIBLOGICALACCESS_API
-#define LIBLOGICALACCESS_API
-#endif
-#ifndef DISABLE_PRAGMA_WARNING
-#define DISABLE_PRAGMA_WARNING /**< \brief winsmcrd.h was modified to support this macro, to avoid MSVC specific warnings pragma */
-#endif
-#endif
+#include "logicalaccess/logicalaccess_api.hpp"
 
 extern "C"
 {

--- a/plugins/pluginsreaderproviders/sciel/readercardadapters/scieldatatransport.cpp
+++ b/plugins/pluginsreaderproviders/sciel/readercardadapters/scieldatatransport.cpp
@@ -4,6 +4,7 @@
  * \brief Sciel buffer parser.
  */
 
+#include <logicalaccess/logs.hpp>
 #include "scieldatatransport.hpp"
 #include "logicalaccess/bufferhelper.hpp"
 

--- a/plugins/pluginsreaderproviders/sciel/readercardadapters/scieldatatransport.hpp
+++ b/plugins/pluginsreaderproviders/sciel/readercardadapters/scieldatatransport.hpp
@@ -12,6 +12,7 @@
 
 #include <string>
 #include <vector>
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/sciel/readercardadapters/scielreadercardadapter.cpp
+++ b/plugins/pluginsreaderproviders/sciel/readercardadapters/scielreadercardadapter.cpp
@@ -6,6 +6,8 @@
 
 #include "scielreadercardadapter.hpp"
 #include "scieldatatransport.hpp"
+#include "logicalaccess/bufferhelper.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/sciel/scielreaderprovider.cpp
+++ b/plugins/pluginsreaderproviders/sciel/scielreaderprovider.cpp
@@ -6,6 +6,7 @@
 
 #include "scielreaderprovider.hpp"
 #include "logicalaccess/readerproviders/serialportdatatransport.hpp"
+#include "logicalaccess/myexception.hpp"
 
 #ifdef __unix__
 #include <stdlib.h>

--- a/plugins/pluginsreaderproviders/sciel/scielreaderunit.cpp
+++ b/plugins/pluginsreaderproviders/sciel/scielreaderunit.cpp
@@ -16,6 +16,10 @@
 #include "readercardadapters/scielreadercardadapter.hpp"
 #include <boost/filesystem.hpp>
 #include "readercardadapters/scieldatatransport.hpp"
+#include "logicalaccess/settings.hpp"
+#include "logicalaccess/bufferhelper.hpp"
+#include "logicalaccess/myexception.hpp"
+#include <boost/property_tree/xml_parser.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/sciel/scielreaderunitconfiguration.cpp
+++ b/plugins/pluginsreaderproviders/sciel/scielreaderunitconfiguration.cpp
@@ -7,6 +7,8 @@
 #include "scielreaderunitconfiguration.hpp"
 #include "scielreaderprovider.hpp"
 
+#include <boost/property_tree/ptree.hpp>
+
 #ifdef UNIX
 # include <termios.h>
 # include <unistd.h>

--- a/plugins/pluginsreaderproviders/smartid/commands/mifaresmartidcommands.cpp
+++ b/plugins/pluginsreaderproviders/smartid/commands/mifaresmartidcommands.cpp
@@ -4,12 +4,14 @@
  * \brief Mifare SmartID commands.
  */
 
+#include <string.h>
 #include "mifaresmartidcommands.hpp"
 #include "../smartidreaderprovider.hpp"
 #include "mifarechip.hpp"
 #include "logicalaccess/cards/computermemorykeystorage.hpp"
 #include "logicalaccess/cards/readermemorykeystorage.hpp"
 #include "logicalaccess/cards/samkeystorage.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/smartid/libraryentry.cpp
+++ b/plugins/pluginsreaderproviders/smartid/libraryentry.cpp
@@ -2,17 +2,7 @@
 #include <memory>
 #include "logicalaccess/readerproviders/readerprovider.hpp"
 #include "smartidreaderprovider.hpp"
-
-#ifdef _MSC_VER
-#include "logicalaccess/msliblogicalaccess.h"
-#else
-#ifndef LIBLOGICALACCESS_API
-#define LIBLOGICALACCESS_API
-#endif
-#ifndef DISABLE_PRAGMA_WARNING
-#define DISABLE_PRAGMA_WARNING /**< \brief winsmcrd.h was modified to support this macro, to avoid MSVC specific warnings pragma */
-#endif
-#endif
+#include "logicalaccess/logicalaccess_api.hpp"
 
 extern "C"
 {

--- a/plugins/pluginsreaderproviders/smartid/smartid_fwd.hpp
+++ b/plugins/pluginsreaderproviders/smartid/smartid_fwd.hpp
@@ -1,0 +1,14 @@
+//
+// Created by xaqq on 6/24/15.
+//
+
+#ifndef LIBLOGICALACCESS_SMARTID_FWD_HPP
+#define LIBLOGICALACCESS_SMARTID_FWD_HPP
+
+namespace logicalaccess
+{
+    class SmartIDLEDBuzzerDisplay;
+    class SmartIDReaderCardAdapter;
+}
+
+#endif //LIBLOGICALACCESS_SMARTID_FWD_HPP

--- a/plugins/pluginsreaderproviders/smartid/smartidledbuzzerdisplay.cpp
+++ b/plugins/pluginsreaderproviders/smartid/smartidledbuzzerdisplay.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "smartidledbuzzerdisplay.hpp"
+#include "readercardadapters/smartidreadercardadapter.hpp"
 
 namespace logicalaccess
 {
@@ -77,4 +78,7 @@ namespace logicalaccess
             setPort();
         }
     }
+
+    std::shared_ptr<SmartIDReaderCardAdapter> SmartIDLEDBuzzerDisplay::getSmartIDReaderCardAdapter()
+    { return std::dynamic_pointer_cast<SmartIDReaderCardAdapter>(getReaderCardAdapter()); }
 }

--- a/plugins/pluginsreaderproviders/smartid/smartidledbuzzerdisplay.hpp
+++ b/plugins/pluginsreaderproviders/smartid/smartidledbuzzerdisplay.hpp
@@ -7,12 +7,10 @@
 #ifndef LOGICALACCESS_SMARTIDLEDBUZZERDISPLAY_HPP
 #define LOGICALACCESS_SMARTIDLEDBUZZERDISPLAY_HPP
 
-#include "readercardadapters/smartidreadercardadapter.hpp"
-
 #include <string>
 #include <vector>
-
-#include "logicalaccess/logs.hpp"
+#include <logicalaccess/readerproviders/ledbuzzerdisplay.hpp>
+#include "smartid_fwd.hpp"
 
 namespace logicalaccess
 {
@@ -85,7 +83,7 @@ namespace logicalaccess
          */
         void setPort(bool red, bool green, bool buzzer);
 
-        std::shared_ptr<SmartIDReaderCardAdapter> getSmartIDReaderCardAdapter() { return std::dynamic_pointer_cast<SmartIDReaderCardAdapter>(getReaderCardAdapter()); };
+        std::shared_ptr<SmartIDReaderCardAdapter> getSmartIDReaderCardAdapter();;
 
     protected:
 

--- a/plugins/pluginsreaderproviders/smartid/smartidreaderprovider.cpp
+++ b/plugins/pluginsreaderproviders/smartid/smartidreaderprovider.cpp
@@ -16,6 +16,7 @@
 #include <iomanip>
 
 #include "smartidreaderunit.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/smartid/smartidreaderunit.cpp
+++ b/plugins/pluginsreaderproviders/smartid/smartidreaderunit.cpp
@@ -18,9 +18,11 @@
 #include "readercardadapters/smartidreadercardadapter.hpp"
 #include "smartidledbuzzerdisplay.hpp"
 #include <boost/filesystem.hpp>
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/dynlibrary/librarymanager.hpp"
 #include "logicalaccess/dynlibrary/idynlibrary.hpp"
 #include "logicalaccess/readerproviders/serialportdatatransport.hpp"
+#include <boost/property_tree/xml_parser.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/smartid/smartidreaderunitconfiguration.cpp
+++ b/plugins/pluginsreaderproviders/smartid/smartidreaderunitconfiguration.cpp
@@ -6,10 +6,12 @@
 
 #include "smartidreaderunitconfiguration.hpp"
 #include "smartidreaderprovider.hpp"
+#include <boost/property_tree/ptree.hpp>
 
 #ifdef UNIX
 # include <termios.h>
 # include <unistd.h>
+
 #endif
 
 namespace logicalaccess

--- a/plugins/pluginsreaderproviders/stidstr/commands/desfireev1stidstrcommands.cpp
+++ b/plugins/pluginsreaderproviders/stidstr/commands/desfireev1stidstrcommands.cpp
@@ -7,6 +7,7 @@
 #include "desfireev1stidstrcommands.hpp"
 #include "desfirechip.hpp"
 #include <openssl/rand.h>
+#include <string.h>
 #include "logicalaccess/logs.hpp"
 #include "logicalaccess/crypto/aes_cipher.hpp"
 #include "logicalaccess/crypto/aes_symmetric_key.hpp"
@@ -17,6 +18,7 @@
 #include "desfireprofile.hpp"
 #include "logicalaccess/cards/computermemorykeystorage.hpp"
 #include "logicalaccess/cards/readermemorykeystorage.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {
@@ -86,9 +88,9 @@ namespace logicalaccess
         return freemem;
     }
 
-    vector<DFName> DESFireEV1STidSTRCommands::getDFNames()
+    std::vector<DFName> DESFireEV1STidSTRCommands::getDFNames()
     {
-        vector<DFName> dfnames;
+        std::vector<DFName> dfnames;
 
         LOG(LogLevel::ERRORS) << "Function not available with this reader.";
         THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "Function not available with this reader.");
@@ -96,9 +98,9 @@ namespace logicalaccess
         return dfnames;
     }
 
-    vector<unsigned short> DESFireEV1STidSTRCommands::getISOFileIDs()
+    std::vector<unsigned short> DESFireEV1STidSTRCommands::getISOFileIDs()
     {
-        vector<unsigned short> fileids;
+        std::vector<unsigned short> fileids;
 
         LOG(LogLevel::ERRORS) << "Function not available with this reader.";
         THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "Function not available with this reader.");

--- a/plugins/pluginsreaderproviders/stidstr/commands/mifarestidstrcommands.cpp
+++ b/plugins/pluginsreaderproviders/stidstr/commands/mifarestidstrcommands.cpp
@@ -10,6 +10,7 @@
 #include "logicalaccess/cards/computermemorykeystorage.hpp"
 #include "logicalaccess/cards/readermemorykeystorage.hpp"
 #include "logicalaccess/cards/samkeystorage.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/stidstr/libraryentry.cpp
+++ b/plugins/pluginsreaderproviders/stidstr/libraryentry.cpp
@@ -2,17 +2,7 @@
 #include <memory>
 #include "logicalaccess/readerproviders/readerprovider.hpp"
 #include "stidstrreaderprovider.hpp"
-
-#ifdef _MSC_VER
-#include "logicalaccess/msliblogicalaccess.h"
-#else
-#ifndef LIBLOGICALACCESS_API
-#define LIBLOGICALACCESS_API
-#endif
-#ifndef DISABLE_PRAGMA_WARNING
-#define DISABLE_PRAGMA_WARNING /**< \brief winsmcrd.h was modified to support this macro, to avoid MSVC specific warnings pragma */
-#endif
-#endif
+#include "logicalaccess/logicalaccess_api.hpp"
 
 extern "C"
 {

--- a/plugins/pluginsreaderproviders/stidstr/readercardadapters/stidstrreaderbufferparser.cpp
+++ b/plugins/pluginsreaderproviders/stidstr/readercardadapters/stidstrreaderbufferparser.cpp
@@ -4,6 +4,7 @@
  * \brief STidSTR buffer parser.
  */
 
+#include <logicalaccess/logs.hpp>
 #include "stidstrreaderbufferparser.hpp"
 #include "logicalaccess/bufferhelper.hpp"
 

--- a/plugins/pluginsreaderproviders/stidstr/readercardadapters/stidstrreadercardadapter.cpp
+++ b/plugins/pluginsreaderproviders/stidstr/readercardadapters/stidstrreadercardadapter.cpp
@@ -13,6 +13,8 @@
 #include "logicalaccess/crypto/aes_cipher.hpp"
 #include "logicalaccess/crypto/aes_initialization_vector.hpp"
 #include "logicalaccess/crypto/aes_symmetric_key.hpp"
+#include "../stidstrreaderunitconfiguration.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/stidstr/readercardadapters/stidstrreaderdatatransport.hpp
+++ b/plugins/pluginsreaderproviders/stidstr/readercardadapters/stidstrreaderdatatransport.hpp
@@ -12,6 +12,7 @@
 
 #include <string>
 #include <vector>
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/stidstr/stidstr_fwd.hpp
+++ b/plugins/pluginsreaderproviders/stidstr/stidstr_fwd.hpp
@@ -1,0 +1,15 @@
+//
+// Created by xaqq on 6/24/15.
+//
+
+#ifndef LIBLOGICALACCESS_STIDSTR_FWD_HPP
+#define LIBLOGICALACCESS_STIDSTR_FWD_HPP
+
+namespace logicalaccess
+{
+    class STidSTRReaderCardAdapter;
+    class STidSTRReaderProvider;
+    class STidSTRReaderUnitConfiguration;
+}
+
+#endif //LIBLOGICALACCESS_STIDSTR_FWD_HPP

--- a/plugins/pluginsreaderproviders/stidstr/stidstrledbuzzerdisplay.cpp
+++ b/plugins/pluginsreaderproviders/stidstr/stidstrledbuzzerdisplay.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "stidstrledbuzzerdisplay.hpp"
+#include "readercardadapters/stidstrreadercardadapter.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/stidstr/stidstrledbuzzerdisplay.hpp
+++ b/plugins/pluginsreaderproviders/stidstr/stidstrledbuzzerdisplay.hpp
@@ -7,12 +7,10 @@
 #ifndef LOGICALACCESS_STIDSTRLEDBUZZERDISPLAY_HPP
 #define LOGICALACCESS_STIDSTRLEDBUZZERDISPLAY_HPP
 
-#include "readercardadapters/stidstrreadercardadapter.hpp"
-
 #include <string>
 #include <vector>
-
-#include "logicalaccess/logs.hpp"
+#include "logicalaccess/readerproviders/ledbuzzerdisplay.hpp"
+#include "stidstr_fwd.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/stidstr/stidstrreaderprovider.cpp
+++ b/plugins/pluginsreaderproviders/stidstr/stidstrreaderprovider.cpp
@@ -14,8 +14,10 @@
 
 #include <sstream>
 #include <iomanip>
+#include <logicalaccess/logs.hpp>
 
 #include "stidstrreaderunit.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/stidstr/stidstrreaderprovider.hpp
+++ b/plugins/pluginsreaderproviders/stidstr/stidstrreaderprovider.hpp
@@ -8,7 +8,6 @@
 #define LOGICALACCESS_READERSTIDSTR_PROVIDER_HPP
 
 #include "logicalaccess/readerproviders/readerprovider.hpp"
-#include "stidstrreaderunit.hpp"
 
 namespace logicalaccess
 {

--- a/plugins/pluginsreaderproviders/stidstr/stidstrreaderunit.cpp
+++ b/plugins/pluginsreaderproviders/stidstr/stidstrreaderunit.cpp
@@ -28,11 +28,16 @@
 #include "commands/mifarestidstrcommands.hpp"
 #include "desfireprofile.hpp"
 #include <boost/filesystem.hpp>
+#include <logicalaccess/myexception.hpp>
 #include "logicalaccess/dynlibrary/librarymanager.hpp"
 #include "logicalaccess/dynlibrary/idynlibrary.hpp"
 #include "readercardadapters/stidstrreaderdatatransport.hpp"
 #include "desfireev1chip.hpp"
 #include "mifarechip.hpp"
+
+#include "stidstrreaderunitconfiguration.hpp"
+#include "logicalaccess/settings.hpp"
+#include <boost/property_tree/xml_parser.hpp>
 
 namespace logicalaccess
 {
@@ -829,5 +834,10 @@ namespace logicalaccess
         std::vector<unsigned char> response = getDefaultSTidSTRReaderCardAdapter()->sendCommand(0x000E, std::vector<unsigned char>(), statusCode);
 
         EXCEPTION_ASSERT_WITH_LOG(response.size() == 0, LibLogicalAccessException, "Unable to load the SKB values. An unknown error occured.");
+    }
+
+    std::shared_ptr<STidSTRReaderUnitConfiguration> STidSTRReaderUnit::getSTidSTRConfiguration()
+    {
+        return std::dynamic_pointer_cast<STidSTRReaderUnitConfiguration>(getConfiguration());
     }
 }

--- a/plugins/pluginsreaderproviders/stidstr/stidstrreaderunit.hpp
+++ b/plugins/pluginsreaderproviders/stidstr/stidstrreaderunit.hpp
@@ -8,14 +8,10 @@
 #define LOGICALACCESS_STIDSTRREADERUNIT_HPP
 
 #include "logicalaccess/readerproviders/readerunit.hpp"
-#include "stidstrreaderunitconfiguration.hpp"
+#include "stidstr_fwd.hpp"
 
 namespace logicalaccess
 {
-    class Profile;
-    class STidSTRReaderCardAdapter;
-    class STidSTRReaderProvider;
-
     /**
      * \brief The STid baudrates.
      */
@@ -169,11 +165,7 @@ namespace logicalaccess
          */
         virtual void unSerialize(boost::property_tree::ptree& node);
 
-        /**
-         * \brief Get the STidSTR reader unit configuration.
-         * \return The STidSTR reader unit configuration.
-         */
-        std::shared_ptr<STidSTRReaderUnitConfiguration> getSTidSTRConfiguration() { return std::dynamic_pointer_cast<STidSTRReaderUnitConfiguration>(getConfiguration()); };
+        std::shared_ptr<STidSTRReaderUnitConfiguration> getSTidSTRConfiguration();;
 
         /**
          * \brief Get the STidSTR reader provider.

--- a/plugins/pluginsreaderproviders/stidstr/stidstrreaderunitconfiguration.cpp
+++ b/plugins/pluginsreaderproviders/stidstr/stidstrreaderunitconfiguration.cpp
@@ -4,6 +4,8 @@
  * \brief STidSTR reader unit configuration.
  */
 
+#include <boost/property_tree/ptree.hpp>
+#include <logicalaccess/logs.hpp>
 #include "stidstrreaderunitconfiguration.hpp"
 #include "stidstrreaderprovider.hpp"
 

--- a/src/cards/accessinfos.cpp
+++ b/src/cards/accessinfos.cpp
@@ -16,6 +16,7 @@
 
 #include <iostream>
 #include <string>
+#include <iomanip>
 
 namespace logicalaccess
 {

--- a/src/cards/aes128key.cpp
+++ b/src/cards/aes128key.cpp
@@ -5,6 +5,8 @@
  */
 
 #include "logicalaccess/cards/aes128key.hpp"
+#include <cstring>
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/src/cards/computermemorykeystorage.cpp
+++ b/src/cards/computermemorykeystorage.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "logicalaccess/cards/computermemorykeystorage.hpp"
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/src/cards/hmac1key.cpp
+++ b/src/cards/hmac1key.cpp
@@ -5,6 +5,8 @@
  */
 
 #include "logicalaccess/cards/hmac1key.hpp"
+#include <cstring>
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/src/cards/key.cpp
+++ b/src/cards/key.cpp
@@ -20,6 +20,7 @@
 #include "logicalaccess/bufferhelper.hpp"
 
 #include <openssl/rand.h>
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/src/cards/readercardadapter.cpp
+++ b/src/cards/readercardadapter.cpp
@@ -6,6 +6,8 @@
 
 #include "logicalaccess/cards/readercardadapter.hpp"
 #include "logicalaccess/bufferhelper.hpp"
+#include "logicalaccess/myexception.hpp"
+#include "logicalaccess/logs.hpp"
 
 namespace logicalaccess
 {

--- a/src/cards/readermemorykeystorage.cpp
+++ b/src/cards/readermemorykeystorage.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "logicalaccess/cards/readermemorykeystorage.hpp"
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/src/cards/samkeystorage.cpp
+++ b/src/cards/samkeystorage.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "logicalaccess/cards/samkeystorage.hpp"
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/src/cards/tripledeskey.cpp
+++ b/src/cards/tripledeskey.cpp
@@ -5,6 +5,8 @@
  */
 
 #include "logicalaccess/cards/tripledeskey.hpp"
+#include <cstring>
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/src/dynlibrary/librarymanager.cpp
+++ b/src/dynlibrary/librarymanager.cpp
@@ -6,6 +6,7 @@
 #include "logicalaccess/readerproviders/tcpdatatransport.hpp"
 #include "logicalaccess/readerproviders/udpdatatransport.hpp"
 #include "logicalaccess/cards/keydiversification.hpp"
+#include "logicalaccess/settings.hpp"
 
 namespace logicalaccess
 {

--- a/src/dynlibrary/posixdynlibrary.cpp
+++ b/src/dynlibrary/posixdynlibrary.cpp
@@ -1,6 +1,7 @@
 #include <dlfcn.h>
 
 #include "logicalaccess/dynlibrary/posixdynlibrary.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/src/logs.cpp
+++ b/src/logs.cpp
@@ -5,6 +5,8 @@
  */
 
 #include "logicalaccess/logs.hpp"
+#include "logicalaccess/settings.hpp"
+#include <boost/date_time.hpp>
 
 namespace logicalaccess
 {

--- a/src/readerproviders/datatransport.cpp
+++ b/src/readerproviders/datatransport.cpp
@@ -6,6 +6,7 @@
 
 #include "logicalaccess/readerproviders/datatransport.hpp"
 #include "logicalaccess/bufferhelper.hpp"
+#include "logicalaccess/logs.hpp"
 
 namespace logicalaccess
 {

--- a/src/readerproviders/readerconfiguration.cpp
+++ b/src/readerproviders/readerconfiguration.cpp
@@ -10,9 +10,11 @@
 #include "logicalaccess/cards/accessinfo.hpp"
 #include "logicalaccess/dynlibrary/idynlibrary.hpp"
 #include <boost/filesystem.hpp>
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/dynlibrary/librarymanager.hpp"
 
 #include "logicalaccess/logs.hpp"
+#include "logicalaccess/settings.hpp"
 
 namespace logicalaccess
 {

--- a/src/readerproviders/readerprovider.cpp
+++ b/src/readerproviders/readerprovider.cpp
@@ -12,6 +12,8 @@
 #include "logicalaccess/dynlibrary/librarymanager.hpp"
 #include "logicalaccess/logs.hpp"
 
+#include <thread>
+
 namespace logicalaccess
 {
     ReaderProvider::ReaderProvider()

--- a/src/readerproviders/readerunit.cpp
+++ b/src/readerproviders/readerunit.cpp
@@ -24,6 +24,13 @@
 #include <boost/filesystem.hpp>
 #include <boost/foreach.hpp>
 #include <map>
+#include "logicalaccess/bufferhelper.hpp"
+
+#include "logicalaccess/readerproviders/lcddisplay.hpp"
+#include "logicalaccess/readerproviders/ledbuzzerdisplay.hpp"
+#include "logicalaccess/readerproviders/readerunitconfiguration.hpp"
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
 
 namespace logicalaccess
 {

--- a/src/readerproviders/serialport.cpp
+++ b/src/readerproviders/serialport.cpp
@@ -11,6 +11,8 @@
 
 #include <boost/asio.hpp>
 #include <boost/asio/basic_serial_port.hpp>
+#include <boost/bind/bind.hpp>
+#include "logicalaccess/logs.hpp"
 
 namespace logicalaccess
 {

--- a/src/readerproviders/serialportdatatransport.cpp
+++ b/src/readerproviders/serialportdatatransport.cpp
@@ -8,6 +8,9 @@
 #include "logicalaccess/readerproviders/serialportdatatransport.hpp"
 #include "logicalaccess/cards/readercardadapter.hpp"
 #include "logicalaccess/bufferhelper.hpp"
+#include "logicalaccess/settings.hpp"
+#include "logicalaccess/logs.hpp"
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/src/readerproviders/serialportxml.cpp
+++ b/src/readerproviders/serialportxml.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "logicalaccess/readerproviders/serialportxml.hpp"
+#include "logicalaccess/myexception.hpp"
 
 #ifdef UNIX
 #include <fcntl.h>
@@ -14,6 +15,7 @@
 #endif
 
 #include "logicalaccess/logs.hpp"
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/src/readerproviders/tcpdatatransport.cpp
+++ b/src/readerproviders/tcpdatatransport.cpp
@@ -12,6 +12,8 @@
 #include <boost/foreach.hpp>
 #include <boost/optional.hpp>
 #include <boost/array.hpp>
+#include <logicalaccess/logs.hpp>
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/src/readerproviders/udpdatatransport.cpp
+++ b/src/readerproviders/udpdatatransport.cpp
@@ -10,6 +10,8 @@
 #include <boost/foreach.hpp>
 #include <boost/optional.hpp>
 #include <boost/array.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <thread>
 
 namespace logicalaccess
 {

--- a/src/resultchecker.cpp
+++ b/src/resultchecker.cpp
@@ -5,6 +5,8 @@
  */
 
 #include "logicalaccess/resultchecker.hpp"
+#include "logicalaccess/myexception.hpp"
+#include "logicalaccess/logs.hpp"
 
 namespace logicalaccess
 {

--- a/src/services/accesscontrol/cardsformatcomposite.cpp
+++ b/src/services/accesscontrol/cardsformatcomposite.cpp
@@ -10,6 +10,8 @@
 #include "logicalaccess/cards/chip.hpp"
 #include "logicalaccess/services/accesscontrol/accesscontrolcardservice.hpp"
 #include <boost/foreach.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
 
 namespace logicalaccess
 {

--- a/src/services/accesscontrol/formats/asciiformat.cpp
+++ b/src/services/accesscontrol/formats/asciiformat.cpp
@@ -4,6 +4,8 @@
  * \brief ASCII Format.
  */
 
+#include <cstring>
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/services/accesscontrol/formats/asciiformat.hpp"
 #include "logicalaccess/services/accesscontrol/formats/bithelper.hpp"
 #include "logicalaccess/services/accesscontrol/encodings/binarydatatype.hpp"

--- a/src/services/accesscontrol/formats/bariumferritepcscformat.cpp
+++ b/src/services/accesscontrol/formats/bariumferritepcscformat.cpp
@@ -4,6 +4,7 @@
  * \brief Barium Ferrite PCSC Format.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/myexception.hpp"
 #include "logicalaccess/services/accesscontrol/formats/bariumferritepcscformat.hpp"
 #include "logicalaccess/services/accesscontrol/formats/bithelper.hpp"

--- a/src/services/accesscontrol/formats/bithelper.cpp
+++ b/src/services/accesscontrol/formats/bithelper.cpp
@@ -5,7 +5,7 @@
  */
 
 #include "logicalaccess/services/accesscontrol/formats/bithelper.hpp"
-
+#include "logicalaccess/logs.hpp"
 #include <cstring>
 
 namespace logicalaccess

--- a/src/services/accesscontrol/formats/corporate1000format.cpp
+++ b/src/services/accesscontrol/formats/corporate1000format.cpp
@@ -4,12 +4,15 @@
  * \brief Corporate 1000 format.
  */
 
+#include <cstring>
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/services/accesscontrol/formats/corporate1000format.hpp"
 #include "logicalaccess/services/accesscontrol/formats/bithelper.hpp"
 #include "logicalaccess/services/accesscontrol/encodings/binarydatatype.hpp"
 #include "logicalaccess/services/accesscontrol/encodings/bigendiandatarepresentation.hpp"
 
 #include "logicalaccess/services/accesscontrol/formats/customformat/numberdatafield.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/src/services/accesscontrol/formats/customformat/binarydatafield.cpp
+++ b/src/services/accesscontrol/formats/customformat/binarydatafield.cpp
@@ -8,10 +8,8 @@
 #include "logicalaccess/services/accesscontrol/encodings/bigendiandatarepresentation.hpp"
 #include "logicalaccess/services/accesscontrol/formats/bithelper.hpp"
 #include "logicalaccess/services/accesscontrol/formats/customformat/binarydatafield.hpp"
-
-#ifdef __unix__
 #include <cstring>
-#endif
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/src/services/accesscontrol/formats/customformat/customformat.cpp
+++ b/src/services/accesscontrol/formats/customformat/customformat.cpp
@@ -18,6 +18,7 @@
 #include <stdlib.h>
 
 #include <boost/foreach.hpp>
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/src/services/accesscontrol/formats/customformat/datafield.cpp
+++ b/src/services/accesscontrol/formats/customformat/datafield.cpp
@@ -8,6 +8,7 @@
 #include "logicalaccess/services/accesscontrol/formats/bithelper.hpp"
 
 #include <stdlib.h>
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/src/services/accesscontrol/formats/customformat/numberdatafield.cpp
+++ b/src/services/accesscontrol/formats/customformat/numberdatafield.cpp
@@ -4,6 +4,7 @@
  * \brief Number Data field.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/myexception.hpp"
 #include "logicalaccess/services/accesscontrol/formats/customformat/numberdatafield.hpp"
 

--- a/src/services/accesscontrol/formats/customformat/paritydatafield.cpp
+++ b/src/services/accesscontrol/formats/customformat/paritydatafield.cpp
@@ -10,6 +10,7 @@
 #include "logicalaccess/services/accesscontrol/formats/bithelper.hpp"
 
 #include <boost/foreach.hpp>
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/src/services/accesscontrol/formats/customformat/stringdatafield.cpp
+++ b/src/services/accesscontrol/formats/customformat/stringdatafield.cpp
@@ -4,8 +4,11 @@
  * \brief String Data field.
  */
 
+#include <cstring>
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/services/accesscontrol/formats/customformat/stringdatafield.hpp"
 #include "logicalaccess/bufferhelper.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/src/services/accesscontrol/formats/customformat/valuedatafield.cpp
+++ b/src/services/accesscontrol/formats/customformat/valuedatafield.cpp
@@ -8,9 +8,11 @@
 #include "logicalaccess/services/accesscontrol/formats/bithelper.hpp"
 #include "logicalaccess/services/accesscontrol/encodings/bigendiandatarepresentation.hpp"
 #include "logicalaccess/services/accesscontrol/encodings/binarydatatype.hpp"
+#include "logicalaccess/myexception.hpp"
 
 #include <cstring>
 #include <stdlib.h>
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/src/services/accesscontrol/formats/dataclockformat.cpp
+++ b/src/services/accesscontrol/formats/dataclockformat.cpp
@@ -4,12 +4,14 @@
  * \brief Data clock Format.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/services/accesscontrol/formats/dataclockformat.hpp"
 #include "logicalaccess/services/accesscontrol/formats/bithelper.hpp"
 #include "logicalaccess/services/accesscontrol/encodings/bcdnibbledatatype.hpp"
 #include "logicalaccess/services/accesscontrol/encodings/littleendiandatarepresentation.hpp"
 
 #include "logicalaccess/services/accesscontrol/formats/customformat/numberdatafield.hpp"
+#include "logicalaccess/myexception.hpp"
 
 namespace logicalaccess
 {

--- a/src/services/accesscontrol/formats/fascn200bitformat.cpp
+++ b/src/services/accesscontrol/formats/fascn200bitformat.cpp
@@ -4,6 +4,8 @@
  * \brief FASC-N 200 Bit format.
  */
 
+#include <cstring>
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/myexception.hpp"
 #include "logicalaccess/services/accesscontrol/formats/fascn200bitformat.hpp"
 #include "logicalaccess/services/accesscontrol/formats/bithelper.hpp"

--- a/src/services/accesscontrol/formats/getronik40bitformat.cpp
+++ b/src/services/accesscontrol/formats/getronik40bitformat.cpp
@@ -4,6 +4,7 @@
  * \brief Getronik 40-Bit Format.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/myexception.hpp"
 #include "logicalaccess/services/accesscontrol/formats/getronik40bitformat.hpp"
 #include "logicalaccess/services/accesscontrol/formats/bithelper.hpp"

--- a/src/services/accesscontrol/formats/hidhoneywellformat.cpp
+++ b/src/services/accesscontrol/formats/hidhoneywellformat.cpp
@@ -4,6 +4,7 @@
  * \brief HID Honeywell Format.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/myexception.hpp"
 #include "logicalaccess/services/accesscontrol/formats/hidhoneywellformat.hpp"
 #include "logicalaccess/services/accesscontrol/formats/bithelper.hpp"

--- a/src/services/accesscontrol/formats/rawformat.cpp
+++ b/src/services/accesscontrol/formats/rawformat.cpp
@@ -4,6 +4,8 @@
  * \brief Raw Format.
  */
 
+#include <cstring>
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/services/accesscontrol/formats/rawformat.hpp"
 #include "logicalaccess/services/accesscontrol/formats/bithelper.hpp"
 #include "logicalaccess/services/accesscontrol/encodings/binarydatatype.hpp"

--- a/src/services/accesscontrol/formats/staticformat.cpp
+++ b/src/services/accesscontrol/formats/staticformat.cpp
@@ -4,9 +4,9 @@
  * \brief Static Format Base.
  */
 
+#include <cstring>
 #include "logicalaccess/services/accesscontrol/formats/staticformat.hpp"
 #include "logicalaccess/services/accesscontrol/formats/bithelper.hpp"
-
 #include "logicalaccess/services/accesscontrol/formats/customformat/numberdatafield.hpp"
 
 namespace logicalaccess

--- a/src/services/accesscontrol/formats/wiegand26format.cpp
+++ b/src/services/accesscontrol/formats/wiegand26format.cpp
@@ -4,6 +4,8 @@
  * \brief Wiegand 26 Format.
  */
 
+#include <cstring>
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/services/accesscontrol/formats/wiegand26format.hpp"
 #include "logicalaccess/services/accesscontrol/formats/customformat/numberdatafield.hpp"
 

--- a/src/services/accesscontrol/formats/wiegand34format.cpp
+++ b/src/services/accesscontrol/formats/wiegand34format.cpp
@@ -4,6 +4,7 @@
  * \brief Wiegand 34 Format.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/services/accesscontrol/formats/wiegand34format.hpp"
 #include "logicalaccess/services/accesscontrol/formats/customformat/numberdatafield.hpp"
 

--- a/src/services/accesscontrol/formats/wiegand34withfacilityformat.cpp
+++ b/src/services/accesscontrol/formats/wiegand34withfacilityformat.cpp
@@ -4,6 +4,8 @@
  * \brief Wiegand 34 With Facility Format.
  */
 
+#include <cstring>
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/services/accesscontrol/formats/wiegand34withfacilityformat.hpp"
 #include "logicalaccess/services/accesscontrol/formats/customformat/numberdatafield.hpp"
 

--- a/src/services/accesscontrol/formats/wiegand37format.cpp
+++ b/src/services/accesscontrol/formats/wiegand37format.cpp
@@ -4,6 +4,7 @@
  * \brief Wiegand 37 Format.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/services/accesscontrol/formats/wiegand37format.hpp"
 #include "logicalaccess/services/accesscontrol/formats/customformat/numberdatafield.hpp"
 

--- a/src/services/accesscontrol/formats/wiegand37withfacilityformat.cpp
+++ b/src/services/accesscontrol/formats/wiegand37withfacilityformat.cpp
@@ -4,6 +4,8 @@
  * \brief Wiegand 37 With Facility Format.
  */
 
+#include <cstring>
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/services/accesscontrol/formats/wiegand37withfacilityformat.hpp"
 #include "logicalaccess/services/accesscontrol/formats/customformat/numberdatafield.hpp"
 

--- a/src/services/accesscontrol/formats/wiegand37withfacilityrightparity2format.cpp
+++ b/src/services/accesscontrol/formats/wiegand37withfacilityrightparity2format.cpp
@@ -4,6 +4,8 @@
  * \brief Wiegand 37 With Facility and right parity * 2 Format.
  */
 
+#include <cstring>
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/myexception.hpp"
 #include "logicalaccess/services/accesscontrol/formats/wiegand37withfacilityrightparity2format.hpp"
 #include "logicalaccess/services/accesscontrol/formats/bithelper.hpp"

--- a/src/services/accesscontrol/readerformatcomposite.cpp
+++ b/src/services/accesscontrol/readerformatcomposite.cpp
@@ -6,6 +6,7 @@
 
 #include "logicalaccess/services/accesscontrol/readerformatcomposite.hpp"
 #include "logicalaccess/cards/accessinfo.hpp"
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/src/services/nfctag/ndefmessage.cpp
+++ b/src/services/nfctag/ndefmessage.cpp
@@ -7,6 +7,7 @@
 #include "logicalaccess/services/nfctag/ndefmessage.hpp"
 #include "logicalaccess/bufferhelper.hpp"
 #include <boost/foreach.hpp>
+#include <boost/property_tree/ptree.hpp>
 
 namespace logicalaccess
 {

--- a/src/services/nfctag/ndefrecord.cpp
+++ b/src/services/nfctag/ndefrecord.cpp
@@ -4,6 +4,7 @@
  * \brief NDEF Record.
  */
 
+#include <boost/property_tree/ptree.hpp>
 #include "logicalaccess/services/nfctag/ndefrecord.hpp"
 #include "logicalaccess/bufferhelper.hpp"
 

--- a/src/xmlserializable.cpp
+++ b/src/xmlserializable.cpp
@@ -4,16 +4,14 @@
  * \brief Xml Serializable.
  */
 
+#include <string>
+#include <vector>
+#include <boost/property_tree/ptree.hpp>
+#include <fstream>
+#include "logicalaccess/logs.hpp"
 #include "logicalaccess/myexception.hpp"
 #include "logicalaccess/xmlserializable.hpp"
-#include "logicalaccess/logs.hpp"
-#include <stdlib.h>
-#include <fstream>
-#include <iostream>
-#include <iomanip>
-#include <sstream>
-#include <cstring>
-#include <boost/algorithm/string.hpp>
+#include <boost/property_tree/xml_parser.hpp>
 
 namespace logicalaccess
 {

--- a/tests/pcsc-tests/iso15693/main.cpp
+++ b/tests/pcsc-tests/iso15693/main.cpp
@@ -1,10 +1,9 @@
 #include "logicalaccess/dynlibrary/idynlibrary.hpp"
 #include "logicalaccess/readerproviders/readerconfiguration.hpp"
 #include "logicalaccess/readerproviders/serialportdatatransport.hpp"
-
 #include "pluginscards/iso15693/iso15693commands.hpp"
 
-
+#include "logicalaccess/bufferhelper.hpp"
 #include "lla-tests/macros.hpp"
 #include "lla-tests/utils.hpp"
 #include <vector>


### PR DESCRIPTION
Rework a lot of include directives in order to reduce unused
include. This notably reduces compilation time.

Remove using std::XXXX from header file.