### PR TITLE
Add support for openSSL 1.1.0.

### DIFF
--- a/plugins/cryptolib/include/logicalaccess/crypto/openssl_symmetric_cipher_context.hpp
+++ b/plugins/cryptolib/include/logicalaccess/crypto/openssl_symmetric_cipher_context.hpp
@@ -52,7 +52,7 @@ namespace logicalaccess
                 /**
                  * \brief The internal OpenSSL context.
                  */
-                EVP_CIPHER_CTX ctx;
+                EVP_CIPHER_CTX *ctx;
 
                 /**
                  * \brief The internal method.
@@ -116,7 +116,7 @@ namespace logicalaccess
             friend class OpenSSLSymmetricCipher;
         };
 
-        inline EVP_CIPHER_CTX* OpenSSLSymmetricCipherContext::ctx() { return &d_information->ctx; }
+        inline EVP_CIPHER_CTX* OpenSSLSymmetricCipherContext::ctx() { return d_information->ctx; }
         inline OpenSSLSymmetricCipher::Method OpenSSLSymmetricCipherContext::method() const { return d_information->method; }
         inline std::vector<unsigned char>& OpenSSLSymmetricCipherContext::data() { return d_information->data; }
     }

--- a/plugins/cryptolib/src/evp_pkey.cpp
+++ b/plugins/cryptolib/src/evp_pkey.cpp
@@ -29,7 +29,11 @@ namespace logicalaccess
 
         int EVPPKey::type() const
         {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
             return EVP_PKEY_type(d_pkey.get()->type);
+#else
+            return EVP_PKEY_base_id(d_pkey.get());
+#endif
         }
 
         EVPPKey EVPPKey::discardPrivateCompound() const

--- a/plugins/cryptolib/src/openssl.cpp
+++ b/plugins/cryptolib/src/openssl.cpp
@@ -18,9 +18,14 @@ namespace logicalaccess
     {
         OpenSSLInitializer::OpenSSLInitializer()
         {
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
             ERR_load_crypto_strings();
             OpenSSL_add_all_algorithms();
             CRYPTO_malloc_init();
+#else
+            OPENSSL_init_ssl(0, NULL);
+            OpenSSL_add_all_algorithms();
+#endif
         }
 
         OpenSSLInitializer::~OpenSSLInitializer()
@@ -29,7 +34,9 @@ namespace logicalaccess
             RAND_cleanup();
             EVP_cleanup();
             ERR_free_strings();
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
             ERR_remove_thread_state(0);
+#endif
         }
     }
 }

--- a/plugins/cryptolib/src/openssl_symmetric_cipher_context.cpp
+++ b/plugins/cryptolib/src/openssl_symmetric_cipher_context.cpp
@@ -10,7 +10,6 @@
 #include "logicalaccess/crypto/symmetric_key.hpp"
 #include "logicalaccess/crypto/sha.hpp"
 #include <assert.h>
-
 #include <cstring>
 
 namespace logicalaccess
@@ -20,12 +19,13 @@ namespace logicalaccess
         OpenSSLSymmetricCipherContext::Information::Information(OpenSSLSymmetricCipher::Method _method) :
             method(_method)
         {
-            EVP_CIPHER_CTX_init(&ctx);
+            ctx = EVP_CIPHER_CTX_new();
+            assert(ctx && "Cannot allocate EVP cipher context.");
         }
 
         OpenSSLSymmetricCipherContext::Information::~Information()
         {
-            EVP_CIPHER_CTX_cleanup(&ctx);
+            EVP_CIPHER_CTX_free(ctx);
         }
 
         OpenSSLSymmetricCipherContext::OpenSSLSymmetricCipherContext(OpenSSLSymmetricCipher::Method _method) :
@@ -36,14 +36,14 @@ namespace logicalaccess
 
         void OpenSSLSymmetricCipherContext::setPadding(bool padding)
         {
-            EVP_CIPHER_CTX_set_padding(&d_information->ctx, padding ? 1 : 0);
+            EVP_CIPHER_CTX_set_padding(d_information->ctx, padding ? 1 : 0);
         }
 
         size_t OpenSSLSymmetricCipherContext::blockSize() const
         {
             assert(d_information);
 
-            return EVP_CIPHER_CTX_block_size(&d_information->ctx);
+            return EVP_CIPHER_CTX_block_size(d_information->ctx);
         }
 
         void OpenSSLSymmetricCipherContext::reset()

--- a/plugins/cryptolib/src/sha.cpp
+++ b/plugins/cryptolib/src/sha.cpp
@@ -7,6 +7,7 @@
 #include "logicalaccess/crypto/sha.hpp"
 
 #include <openssl/evp.h>
+#include <cassert>
 
 namespace logicalaccess
 {
@@ -17,16 +18,27 @@ namespace logicalaccess
             unsigned int len = 32;
             std::vector<unsigned char> r(len);
 
+            EVP_MD_CTX *mdctx_ptr = nullptr;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
             EVP_MD_CTX mdctx;
-
             EVP_MD_CTX_init(&mdctx);
+            mdctx_ptr = &mdctx;
+#else
+            EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
+            assert(mdctx && "Cannot allocate SSL MD CTX");
+            mdctx_ptr = mdctx;
+#endif
 
-            EVP_DigestInit_ex(&mdctx, EVP_sha256(), NULL);
-            EVP_DigestUpdate(&mdctx, &buffer[0], buffer.size());
-            EVP_DigestFinal_ex(&mdctx, reinterpret_cast<unsigned char*>(&r[0]), &len);
+            EVP_DigestInit_ex(mdctx_ptr, EVP_sha256(), NULL);
+            EVP_DigestUpdate(mdctx_ptr, &buffer[0], buffer.size());
+            EVP_DigestFinal_ex(mdctx_ptr, reinterpret_cast<unsigned char*>(&r[0]), &len);
             r.resize(len);
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
             EVP_MD_CTX_cleanup(&mdctx);
+#else
+            EVP_MD_CTX_destroy(mdctx);
+#endif
 
             return r;
         }
@@ -36,16 +48,27 @@ namespace logicalaccess
             unsigned int len = 32;
             std::vector<unsigned char> r(len);
 
+            EVP_MD_CTX *mdctx_ptr = nullptr;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
             EVP_MD_CTX mdctx;
-
             EVP_MD_CTX_init(&mdctx);
+            mdctx_ptr = &mdctx;
+#else
+            EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
+            assert(mdctx && "Cannot allocate SSL MD CTX");
+            mdctx_ptr = mdctx;
+#endif
 
-            EVP_DigestInit_ex(&mdctx, EVP_sha256(), NULL);
-            EVP_DigestUpdate(&mdctx, str.c_str(), str.length());
-            EVP_DigestFinal_ex(&mdctx, reinterpret_cast<unsigned char*>(&r[0]), &len);
+            EVP_DigestInit_ex(mdctx_ptr, EVP_sha256(), NULL);
+            EVP_DigestUpdate(mdctx_ptr, str.c_str(), str.length());
+            EVP_DigestFinal_ex(mdctx_ptr, reinterpret_cast<unsigned char*>(&r[0]), &len);
             r.resize(len);
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
             EVP_MD_CTX_cleanup(&mdctx);
+#else
+            EVP_MD_CTX_destroy(mdctx);
+#endif
 
             return r;
         }
@@ -55,16 +78,27 @@ namespace logicalaccess
         unsigned int len = 20;
         std::vector<unsigned char> r(len);
 
+        EVP_MD_CTX *mdctx_ptr = nullptr;
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         EVP_MD_CTX mdctx;
-
         EVP_MD_CTX_init(&mdctx);
+        mdctx_ptr = &mdctx;
+#else
+        EVP_MD_CTX *mdctx = EVP_MD_CTX_new();
+        assert(mdctx && "Cannot allocate SSL MD CTX");
+        mdctx_ptr = mdctx;
+#endif
 
-        EVP_DigestInit_ex(&mdctx, EVP_sha1(), NULL);
-        EVP_DigestUpdate(&mdctx, &in[0], in.size());
-        EVP_DigestFinal_ex(&mdctx, reinterpret_cast<unsigned char*>(&r[0]), &len);
+        EVP_DigestInit_ex(mdctx_ptr, EVP_sha1(), NULL);
+        EVP_DigestUpdate(mdctx_ptr, &in[0], in.size());
+        EVP_DigestFinal_ex(mdctx_ptr, reinterpret_cast<unsigned char*>(&r[0]), &len);
         r.resize(len);
 
+#if OPENSSL_VERSION_NUMBER < 0x10100000L
         EVP_MD_CTX_cleanup(&mdctx);
+#else
+        EVP_MD_CTX_destroy(mdctx);
+#endif
 
         return r;
     }


### PR DESCRIPTION
Theses changes should be backward compatible as they introduce
preprocessor conditions to check for OPENSSL_VERSION_NUMBER.