### PR TITLE
Fixed nfc compatibility with Mifare Classic

### DIFF
--- a/include/logicalaccess/services/nfctag/nfctagcardservice.hpp
+++ b/include/logicalaccess/services/nfctag/nfctagcardservice.hpp
@@ -15,6 +15,13 @@ namespace logicalaccess
 /**
 * \brief The NFC Tag storage card service base class.
 */
+
+struct MemoryData
+{
+  int byteAddr;
+  unsigned int size;
+};
+
 class LLA_CORE_API NFCTagCardService : public CardService
 {
   public:

--- a/plugins/logicalaccess/plugins/cards/mifare/mifareaccessinfo.cpp
+++ b/plugins/logicalaccess/plugins/cards/mifare/mifareaccessinfo.cpp
@@ -97,6 +97,20 @@ void MifareAccessInfo::SectorAccessBits::setTransportConfiguration()
     }
 }
 
+void MifareAccessInfo::SectorAccessBits::setNfcConfiguration()
+{
+    d_sector_trailer_access_bits.c1 = false;
+    d_sector_trailer_access_bits.c2 = true;
+    d_sector_trailer_access_bits.c3 = true;
+
+    for (unsigned int i = 0; i < 3; ++i)
+    {
+        d_data_blocks_access_bits[i].c1 = false;
+        d_data_blocks_access_bits[i].c2 = false;
+        d_data_blocks_access_bits[i].c3 = false;
+    }
+}
+
 void MifareAccessInfo::SectorAccessBits::setAReadBWriteConfiguration()
 {
     d_sector_trailer_access_bits.c1 = false;
@@ -109,6 +123,61 @@ void MifareAccessInfo::SectorAccessBits::setAReadBWriteConfiguration()
         d_data_blocks_access_bits[i].c2 = false;
         d_data_blocks_access_bits[i].c3 = false;
     }
+}
+void MifareAccessInfo::SectorAccessBits::setAReadNeverWriteConfiguration()
+{
+  d_sector_trailer_access_bits.c1 = false;
+  d_sector_trailer_access_bits.c2 = true;
+  d_sector_trailer_access_bits.c3 = false;
+
+  for (unsigned int i = 0; i < 3; ++i)
+  {
+      d_data_blocks_access_bits[i].c1 = false;
+      d_data_blocks_access_bits[i].c2 = true;
+      d_data_blocks_access_bits[i].c3 = false;
+  }
+}
+
+void MifareAccessInfo::SectorAccessBits::setBReadBWriteConfiguration()
+{
+  d_sector_trailer_access_bits.c1 = true;
+  d_sector_trailer_access_bits.c2 = false;
+  d_sector_trailer_access_bits.c3 = false;
+
+  for (unsigned int i = 0; i < 3; ++i)
+  {
+      d_data_blocks_access_bits[i].c1 = true;
+      d_data_blocks_access_bits[i].c2 = false;
+      d_data_blocks_access_bits[i].c3 = false;
+  }
+}
+
+void MifareAccessInfo::SectorAccessBits::setBReadNeverWriteConfiguration()
+{
+  d_sector_trailer_access_bits.c1 = true;
+  d_sector_trailer_access_bits.c2 = false;
+  d_sector_trailer_access_bits.c3 = true;
+
+  for (unsigned int i = 0; i < 3; ++i)
+  {
+      d_data_blocks_access_bits[i].c1 = true;
+      d_data_blocks_access_bits[i].c2 = false;
+      d_data_blocks_access_bits[i].c3 = true;
+  }
+}
+
+void MifareAccessInfo::SectorAccessBits::setNeverReadNeverWriteConfiguration()
+{
+  d_sector_trailer_access_bits.c1 = true;
+  d_sector_trailer_access_bits.c2 = true;
+  d_sector_trailer_access_bits.c3 = true;
+
+  for (unsigned int i = 0; i < 3; ++i)
+  {
+      d_data_blocks_access_bits[i].c1 = true;
+      d_data_blocks_access_bits[i].c2 = true;
+      d_data_blocks_access_bits[i].c3 = true;
+  }
 }
 
 MifareAccessInfo::MifareAccessInfo()

--- a/plugins/logicalaccess/plugins/cards/mifare/mifareaccessinfo.hpp
+++ b/plugins/logicalaccess/plugins/cards/mifare/mifareaccessinfo.hpp
@@ -200,12 +200,40 @@ class LLA_CARDS_MIFARE_API MifareAccessInfo : public AccessInfo
          * \brief Set A read, B write configuration.
          */
         void setAReadBWriteConfiguration();
+        void setAReadNeverWriteConfiguration();
+        void setBReadBWriteConfiguration();
+        void setBReadNeverWriteConfiguration();
+        void setNeverReadNeverWriteConfiguration();
+        void setNfcConfiguration();
+
+        bool operator==(SectorAccessBits a)
+        {
+          if (a.d_sector_trailer_access_bits.c1 != this->d_sector_trailer_access_bits.c1
+            || a.d_sector_trailer_access_bits.c2 != this->d_sector_trailer_access_bits.c2
+            || a.d_sector_trailer_access_bits.c3 != this->d_sector_trailer_access_bits.c3)
+            return false;
+          for (unsigned int i = 0; i < 3; ++i)
+          {
+            if (a.d_data_blocks_access_bits[i].c1 != this->d_data_blocks_access_bits[i].c1
+              || a.d_data_blocks_access_bits[i].c2 != this->d_data_blocks_access_bits[i].c2
+              || a.d_data_blocks_access_bits[i].c3 != this->d_data_blocks_access_bits[i].c3)
+              return false;
+          }
+          return true;
+        }
+
+        bool operator!=(const SectorAccessBits a)
+        {
+          bool b = (*this) == a;
+          return !b;
+        }
 
         DataBlockAccessBits
             d_data_blocks_access_bits[3]; /**< \brief The data blocks access bits. */
         SectorTrailerAccessBits
             d_sector_trailer_access_bits; /**< \brief The sector trailer access bits. */
     };
+
 
     /**
      * \brief The key A.

--- a/plugins/logicalaccess/plugins/cards/mifare/mifarekey.hpp
+++ b/plugins/logicalaccess/plugins/cards/mifare/mifarekey.hpp
@@ -94,6 +94,24 @@ class LLA_CARDS_MIFARE_API MifareKey : public Key
      */
     std::string getDefaultXmlNodeName() const override;
 
+    bool operator==(MifareKey b)
+    {
+      unsigned char *keyA = this->getData();
+      unsigned char *keyB = b.getData();
+
+      for (unsigned int i = 0; i != 6; i++)
+      {;
+        if (keyA[i] != keyB[i])
+          return false;
+      }
+      return true;
+    }
+
+    bool operator!=(MifareKey b)
+    {
+      bool a = (*this) == b;
+      return !a;
+    }
   private:
     /**
      * \brief The key bytes

--- a/plugins/logicalaccess/plugins/cards/mifare/mifarenfctagcardservice.cpp
+++ b/plugins/logicalaccess/plugins/cards/mifare/mifarenfctagcardservice.cpp
@@ -7,64 +7,496 @@
 #include <logicalaccess/plugins/llacommon/logs.hpp>
 #include <logicalaccess/plugins/cards/mifare/mifarenfctagcardservice.hpp>
 #include <logicalaccess/plugins/cards/mifare/mifarelocation.hpp>
-#include <logicalaccess/services/nfctag/ndefmessage.hpp>
-#include <logicalaccess/services/storage/storagecardservice.hpp>
 #include <logicalaccess/myexception.hpp>
+#include <unordered_map>
 
 namespace logicalaccess
 {
-void MifareNFCTagCardService::writeNDEF(std::shared_ptr<NdefMessage> records)
+void MifareNFCTagCardService::writeInfo(int baseAddr, std::shared_ptr<MifareKey> keyB, ByteVector tmpBuffer, bool useMad, std::shared_ptr<StorageCardService> storage)
+{
+  std::shared_ptr<MifareLocation> location(new MifareLocation());
+  std::shared_ptr<MifareAccessInfo> aiToWrite(new MifareAccessInfo());
+  std::shared_ptr<MifareKey> madKey = std::make_shared<MifareKey>("a0 a1 a2 a3 a4 a5");
+  MifareAccessInfo::SectorAccessBits sab;
+
+  sab.setNfcConfiguration();
+  location->sector = baseAddr / 64;
+  location->block = (baseAddr / 16) % 4;
+  if ((baseAddr / 16) % 4 == 3)
+  {
+    location->sector = location->sector++;
+    location->block = 0;
+  }
+  location->useMAD = useMad;
+  location->aid    = 0x03E1;
+  aiToWrite->keyA.reset(new MifareKey("d3 f7 d3 f7 d3 f7"));
+  aiToWrite->keyB.reset(new MifareKey(keyB->getData(), keyB->getLength()));
+  aiToWrite->sab.setNfcConfiguration();
+  aiToWrite->gpb = 0x40;
+  aiToWrite->madKeyA.reset(new MifareKey(madKey->getData(), madKey->getLength()));
+  aiToWrite->madKeyB.reset(new MifareKey(keyB->getData(), keyB->getLength()));
+  aiToWrite->madGPB = 0xC1;
+
+  int endSector = (baseAddr + tmpBuffer.size()) / 64;
+  if (((baseAddr + tmpBuffer.size()) / 16) % 4 == 3)
+    endSector++;
+  if  ((baseAddr / 16) % 4 == 3)
+    endSector++;
+  while (endSector >= location->sector)
+  {
+    try
+    {
+      storage->writeData(location, std::shared_ptr<AccessInfo>(), aiToWrite,
+                        tmpBuffer, CB_AUTOSWITCHAREA);
+    }
+    catch (std::exception &)
+    {
+      getMifareChip()->getMifareCommands()->changeKeys(KT_KEY_A ,std::make_shared<MifareKey>("ff ff ff ff ff ff"), std::make_shared<MifareKey>("d3 f7 d3 f7 d3 f7"), keyB, endSector, &sab, 0x40);
+      if (endSector == location->sector)
+      {
+        storage->writeData(location, std::shared_ptr<AccessInfo>(), aiToWrite,
+                        tmpBuffer, CB_AUTOSWITCHAREA);
+      }
+    }
+    endSector--;
+  }
+}
+
+void MifareNFCTagCardService::writeInfo(int baseAddr, std::shared_ptr<MifareAccessInfo> aiToWrite, ByteVector tmpBuffer, std::shared_ptr<StorageCardService> storage)
+{
+  std::shared_ptr<MifareLocation> location(new MifareLocation());
+  MifareAccessInfo::SectorAccessBits sab;
+  std::shared_ptr<MifareAccessInfo> newAiToWrite =  std::make_shared<MifareAccessInfo>();
+  std::shared_ptr<MifareKey> nfcKey = std::make_shared<MifareKey>("d3 f7 d3 f7 d3 f7");
+
+  sab.setNfcConfiguration();
+  location->sector = baseAddr / 64;
+  location->block = (baseAddr / 16) % 4;
+  if ((baseAddr / 16) % 4 == 3)
+  {
+    location->sector = location->sector++;
+    location->block = 0;
+  }
+  location->useMAD = false;
+  location->aid    = 0x03E1;
+  newAiToWrite->keyA.reset(new MifareKey(nfcKey->getData(), nfcKey->getLength()));
+  newAiToWrite->keyB.reset(new MifareKey(aiToWrite->keyB->getData(), aiToWrite->keyB->getLength()));
+  newAiToWrite->sab.setNfcConfiguration();
+  newAiToWrite->gpb = 0x40;
+  newAiToWrite->madKeyA.reset(new MifareKey(aiToWrite->madKeyA->getData(), aiToWrite->madKeyA->getLength()));
+  newAiToWrite->madKeyB.reset(new MifareKey(aiToWrite->madKeyB->getData(), aiToWrite->madKeyB->getLength()));
+  newAiToWrite->madGPB = 0xC1;
+
+  int endSector = (baseAddr + tmpBuffer.size()) / 64;
+  if (((baseAddr + tmpBuffer.size()) / 16) % 4 == 3)
+    endSector++;
+  if  ((baseAddr / 16) % 4 == 3)
+    endSector++;
+  while (endSector >= location->sector)
+  {
+    try
+    {
+      storage->writeData(location, std::shared_ptr<AccessInfo>(), newAiToWrite,
+                        tmpBuffer, CB_AUTOSWITCHAREA);
+    }
+    catch (std::exception &)
+    {
+      getMifareChip()->getMifareCommands()->changeKeys(KT_KEY_A , aiToWrite->keyA, std::make_shared<MifareKey>("d3 f7 d3 f7 d3 f7"), aiToWrite->keyB, endSector, &sab, 0x40);
+      if (endSector == location->sector)
+      {
+        storage->writeData(location, std::shared_ptr<AccessInfo>(), newAiToWrite,
+                        tmpBuffer, CB_AUTOSWITCHAREA);
+      }
+    }
+    endSector--;
+  }
+}
+
+void MifareNFCTagCardService::writeNFC(std::shared_ptr<NfcData> records, int sector, std::shared_ptr<AccessInfo> ai, MifareAccessInfo::SectorAccessBits madSab)
+{
+  std::shared_ptr<StorageCardService> storage =
+      std::dynamic_pointer_cast<StorageCardService>(
+          getMifareChip()->getService(CST_STORAGE));
+  std::shared_ptr<MifareLocation> location(new MifareLocation());
+  std::shared_ptr<MifareAccessInfo> aiToWrite = std::dynamic_pointer_cast<MifareAccessInfo>(ai);
+  MifareAccessInfo::SectorAccessBits sab;
+  std::shared_ptr<MifareKey> madKey = std::make_shared<MifareKey>("a0 a1 a2 a3 a4 a5");
+  std::shared_ptr<logicalaccess::MifareKey> keyNdefSector = std::make_shared<logicalaccess::MifareKey>("d3 f7 d3 f7 d3 f7");
+  unsigned char mad;
+  ByteVector madSector;
+  std::map<int, ByteVector > mapBuffer;
+
+  sab.setAReadBWriteConfiguration();
+  if (*(aiToWrite->madKeyA.get()) != *(madKey.get()))
+  {
+    aiToWrite->madGPB = 0xC1;
+    try
+    {
+      madSector = getMifareChip()->getMifareCommands()->readSector(0, 1 ,madKey, aiToWrite->madKeyB, sab, true);
+    }
+    catch (std::exception &)
+    {
+      getMifareChip()->getMifareCommands()->changeKeys(KT_KEY_A ,aiToWrite->madKeyA , madKey, aiToWrite->madKeyB, 0, &sab, aiToWrite->madGPB);
+      madSector = getMifareChip()->getMifareCommands()->readSector(0, 1 ,madKey, aiToWrite->madKeyB, sab, true);
+    }
+    aiToWrite->madKeyA = madKey;
+  }
+  else
+    madSector = getMifareChip()->getMifareCommands()->readSector(0, 1 ,aiToWrite->madKeyA, aiToWrite->madKeyB, sab, true);
+  for (unsigned int i = 2; i + 1 < madSector.size(); i += 2)
+  {
+    if (madSector[i] == 0x03 && madSector[i + 1] == 0xE1)
+    {
+      MifareAccessInfo::SectorAccessBits sab2;
+      sab2.setAReadBWriteConfiguration();
+      try
+      {
+        ByteVector smallBuffer = getMifareChip()->getMifareCommands()->readSector(i / 2, 0, keyNdefSector, aiToWrite->madKeyB, sab2);
+        mapBuffer[i / 2] = smallBuffer;
+      }
+      catch (std::exception &)
+      {
+
+      }
+    }
+  }
+  _memoryList.clear();
+  for (auto it = mapBuffer.begin(); it != mapBuffer.end(); ++it)
+  {
+    if (it->second[0] != 0x03) // if the sector doesn't begin with a ndef message
+      fillMemoryList(it->second);
+  }
+  ByteVector bigBuffer = NfcData::dataToTLV(records);
+  int additionalSectors = bigBuffer.size() / 48;
+  while (additionalSectors >= 0)
+  {
+    madSector[(sector + additionalSectors) * 2] = 0x03;
+    madSector[(sector + additionalSectors) * 2 + 1] = 0xE1;
+    additionalSectors--;
+  }
+  unsigned char *buffer = new unsigned char[madSector.size()];
+  for (unsigned int i = 0; i < madSector.size() - 1; ++i)
+    buffer[i] = madSector[i + 1];
+  buffer[madSector.size() - 1] = 0;
+  mad = getMifareChip()->getMifareCommands()->calculateMADCrc(buffer, madSector.size());
+  delete[] buffer;
+  madSector[0] = mad;
+  getMifareChip()->getMifareCommands()->writeSector(0, 1, madSector, aiToWrite->madKeyA, aiToWrite->madKeyB, sab, true);
+  ByteVector tmpBuffer;
+  int byteAddr = sector * 64;
+  int baseAddr = byteAddr;
+  sab.setNfcConfiguration();
+  for (unsigned int i = 0; i < bigBuffer.size(); i++)
+  {
+    int c = checkForReservedArea(byteAddr);
+    if (c != -1)
+    {
+      writeInfo(baseAddr, aiToWrite, tmpBuffer, storage);
+      byteAddr += c + 1;
+      int mod = byteAddr % 16;
+      if (mod != 0)
+      {
+        mod = 16 - mod;
+        byteAddr += mod;
+      }
+      baseAddr = byteAddr;
+      tmpBuffer.clear();
+    }
+    tmpBuffer.push_back(bigBuffer[i]);
+    byteAddr++;
+  }
+  writeInfo(baseAddr, aiToWrite, tmpBuffer, storage);
+}
+
+void MifareNFCTagCardService::writeNFC(std::shared_ptr<NfcData> records, int sector, std::shared_ptr<MifareKey> keyA, std::shared_ptr<MifareKey> keyB, bool useMad)
 {
     std::shared_ptr<StorageCardService> storage =
         std::dynamic_pointer_cast<StorageCardService>(
             getMifareChip()->getService(CST_STORAGE));
     std::shared_ptr<MifareLocation> location(new MifareLocation());
     std::shared_ptr<MifareAccessInfo> aiToWrite(new MifareAccessInfo());
-    location->sector = 1;
-    location->useMAD = true;
-    location->aid    = 0x03E1;
-    aiToWrite->keyA.reset(new MifareKey("ff ff ff ff ff ff"));
-    aiToWrite->sab.setTransportConfiguration();
-    // aiToWrite->keyB.reset(new MifareKey("ff ff ff ff ff ff"));
-    // aiToWrite->sab.setAReadBWriteConfiguration();
-    aiToWrite->gpb = 0x40;
-    aiToWrite->madKeyA.reset(new MifareKey("ff ff ff ff ff ff"));
-    aiToWrite->madGPB = 0xC1;
+    MifareAccessInfo::SectorAccessBits sab;
+    std::shared_ptr<MifareKey> madKey = std::make_shared<MifareKey>("a0 a1 a2 a3 a4 a5");
+    unsigned char mad;
+    ByteVector madSector;
+    std::map<int, ByteVector > mapBuffer;
 
-    storage->writeData(location, std::shared_ptr<AccessInfo>(), aiToWrite,
-                       NdefMessage::NdefMessageToTLV(records), CB_AUTOSWITCHAREA);
-}
+    sab.setAReadBWriteConfiguration();
+    try
+    {
+      madSector = getMifareChip()->getMifareCommands()->readSector(0, 1 ,madKey, keyB, sab, true);
+    }
+    catch (const std::exception &e)
+    {
+      getMifareChip()->getMifareCommands()->changeKeys(KT_KEY_A ,std::make_shared<MifareKey>("ff ff ff ff ff ff"), madKey, keyB, 0, &sab, 0xC1);
+      madSector = getMifareChip()->getMifareCommands()->readSector(0, 1 ,madKey, keyB, sab, true);
+    }
+    for (unsigned int i = 2; i + 1 < madSector.size(); i += 2)
+    {
+      if (madSector[i] == 0x03 && madSector[i + 1] == 0xE1)
+      {
+        MifareAccessInfo::SectorAccessBits sab2;
+        sab2.setAReadBWriteConfiguration();
+        ByteVector smallBuffer = getMifareChip()->getMifareCommands()->readSector(i / 2, 0,keyA, std::make_shared<MifareKey>("ff ff ff ff ff ff"), sab2);
+        mapBuffer[i / 2] = smallBuffer;
+      }
+    }
+    _memoryList.clear();
+    for (auto it = mapBuffer.begin(); it != mapBuffer.end(); ++it)
+    {
+      if (it->second[0] != 0x03) // if the sector doesn't begin with a ndef message
+        fillMemoryList(it->second);
+    }
+    ByteVector bigBuffer = NfcData::dataToTLV(records);
+    int additionalSectors = bigBuffer.size() / 48;
+    while (additionalSectors >= 0)
+    {
+      madSector[(sector + additionalSectors) * 2] = 0x03;
+      madSector[(sector + additionalSectors) * 2 + 1] = 0xE1;
+      additionalSectors--;
+    }
+    unsigned char *buffer = new unsigned char[madSector.size()];
+    for (unsigned int i = 0; i < madSector.size() - 1; ++i)
+      buffer[i] = madSector[i + 1];
+    buffer[madSector.size() - 1] = 0;
+    mad = getMifareChip()->getMifareCommands()->calculateMADCrc(buffer, madSector.size());
+    delete[] buffer;
+    madSector[0] = mad;
+    getMifareChip()->getMifareCommands()->writeSector(0, 1, madSector, madKey, keyB, sab, true);
+    ByteVector tmpBuffer;
+    int byteAddr = sector * 64;
+    int baseAddr = byteAddr;
+    sab.setNfcConfiguration();
+    for (unsigned int i = 0; i < bigBuffer.size(); i++)
+    {
+      int c = checkForReservedArea(byteAddr);
+      if (c != -1)
+      {
+        writeInfo(baseAddr, keyB, tmpBuffer, useMad, storage);
+        byteAddr += c + 1;
+        int mod = byteAddr % 16;
+        if (mod != 0)
+        {
+          mod = 16 - mod;
+          byteAddr += mod;
+        }
+        baseAddr = byteAddr;
+        tmpBuffer.clear();
+      }
+      tmpBuffer.push_back(bigBuffer[i]);
+      byteAddr++;
+    }
+    writeInfo(baseAddr, keyB, tmpBuffer, useMad, storage);
+  }
 
-std::shared_ptr<NdefMessage> MifareNFCTagCardService::readNDEF()
+std::vector<std::shared_ptr<NfcData> > MifareNFCTagCardService::readNFC()
 {
+    std::vector<std::shared_ptr<NfcData> > stock;
     std::shared_ptr<StorageCardService> storage =
         std::dynamic_pointer_cast<StorageCardService>(
             getMifareChip()->getService(CST_STORAGE));
     std::shared_ptr<MifareLocation> location(new MifareLocation());
+    MifareAccessInfo::SectorAccessBits sab;
+    std::map<int, ByteVector > bigBuffer;
 
-    location->sector = 1;
-    location->useMAD = true;
-    location->aid    = 0x03E1;
-
-    // Read all available data from sector
-    ByteVector data = storage->readData(location, std::shared_ptr<MifareAccessInfo>(), 48,
-                                        CB_AUTOSWITCHAREA);
-    try
+    sab.setAReadBWriteConfiguration();
+    ByteVector madSector = getMifareChip()->getMifareCommands()->readSector(0, 1,std::make_shared<MifareKey>("a0 a1 a2 a3 a4 a5"), std::make_shared<MifareKey>("ff ff ff ff ff ff"), sab);
+    MifareAccessInfo::SectorAccessBits sab2;
+    sab2.setNfcConfiguration();
+    for (unsigned int i = 2; i + 1 < madSector.size(); i += 2)
     {
-        location->sector = 2;
-        ByteVector data2 = storage->readData(
-            location, std::shared_ptr<MifareAccessInfo>(), 48, CB_AUTOSWITCHAREA);
-        data.insert(data.end(), data2.begin(), data2.end());
+      if (madSector[i] == 0x03 && madSector[i + 1] == 0xE1)
+      {
+        ByteVector smallBuffer = getMifareChip()->getMifareCommands()->readSector(i / 2, 0,std::make_shared<MifareKey>("d3 f7 d3 f7 d3 f7"), std::make_shared<MifareKey>("ff ff ff ff ff ff"), sab, true);
+        ByteVector trailer(smallBuffer.begin() + 54, smallBuffer.end() - 6 );
+        smallBuffer.erase(smallBuffer.begin() + 48, smallBuffer.end());
+        if (trailer[0] == 0x7F && trailer[1] == 0x07 && trailer[2] == 0x88 && trailer[3] == 0x40)
+          bigBuffer[i / 2] = smallBuffer;
+      }
     }
-    catch (const std::exception &)
+    _memoryList.clear();
+    for (auto it = bigBuffer.begin(); it != bigBuffer.end(); ++it)
     {
+      if (it->second[0] != 0x03) // if the sector doesn't begin with a ndef message
+        fillMemoryList(it->second);
     }
+    for (unsigned int i = 0; i != _memoryList.size(); i++)
+    {
+      int sector = _memoryList[i].byteAddr / 64;
+      int byte = _memoryList[i].byteAddr % 64;
+      int size = _memoryList[i].size;
+      if (bigBuffer.count(sector) > 0)
+      {
+        bigBuffer[sector].erase(bigBuffer[sector].begin() + byte, bigBuffer[sector].begin() + byte + size);
+      }
+    }
+    ByteVector finalBuffer;
+    for (auto c : bigBuffer)
+      finalBuffer.insert(finalBuffer.end(),c.second.begin(), c.second.end());
+    stock = NfcData::tlvToData(finalBuffer);
+    return stock;
+}
 
-    return NdefMessage::TLVToNdefMessage(data);
+std::vector<std::shared_ptr<NfcData> > MifareNFCTagCardService::readNFC(std::shared_ptr<AccessInfo> ai, unsigned int sector)
+{
+    std::vector<std::shared_ptr<NfcData> > stock;
+    std::shared_ptr<StorageCardService> storage =
+        std::dynamic_pointer_cast<StorageCardService>(
+            getMifareChip()->getService(CST_STORAGE));
+    std::shared_ptr<MifareLocation> location(new MifareLocation());
+    MifareAccessInfo::SectorAccessBits sab;
+    std::map<int, ByteVector > bigBuffer;
+    std::shared_ptr<MifareAccessInfo> aiToWrite = std::dynamic_pointer_cast<MifareAccessInfo>(ai);
+    std::shared_ptr<MifareKey> keyNdefSector = std::make_shared<MifareKey>("d3 f7 d3 f7 d3 f7");
+
+    sab.setAReadBWriteConfiguration();
+
+    ByteVector madSector = getMifareChip()->getMifareCommands()->readSector(0, 1,std::make_shared<MifareKey>("a0 a1 a2 a3 a4 a5"), aiToWrite->madKeyB, sab);
+    MifareAccessInfo::SectorAccessBits sab2;
+    sab2.setNfcConfiguration();
+    if (sector != 0)
+    {
+      ByteVector smallBuffer = getMifareChip()->getMifareCommands()->readSector(sector, 0, keyNdefSector, aiToWrite->keyB, sab, true);
+      ByteVector trailer(smallBuffer.begin() + 54, smallBuffer.end() - 6 );
+      smallBuffer.erase(smallBuffer.begin() + 48, smallBuffer.end());
+      if (trailer[0] == 0x7F && trailer[1] == 0x07 && trailer[2] == 0x88 && trailer[3] == 0x40)
+        bigBuffer[sector] = smallBuffer;
+    }
+    else
+    {
+      for (unsigned int i = 2; i + 1 < madSector.size(); i += 2)
+      {
+        if (madSector[i] == 0x03 && madSector[i + 1] == 0xE1)
+        {
+          ByteVector smallBuffer = getMifareChip()->getMifareCommands()->readSector(i / 2, 0,keyNdefSector, aiToWrite->keyB, sab, true);
+          ByteVector trailer(smallBuffer.begin() + 54, smallBuffer.end() - 6 );
+          smallBuffer.erase(smallBuffer.begin() + 48, smallBuffer.end());
+          if (trailer[0] == 0x7F && trailer[1] == 0x07 && trailer[2] == 0x88 && trailer[3] == 0x40)
+            bigBuffer[i / 2] = smallBuffer;
+        }
+      }
+    }
+    _memoryList.clear();
+    for (auto it = bigBuffer.begin(); it != bigBuffer.end(); ++it)
+    {
+      if (it->second[0] != 0x03) // if the sector doesn't begin with a ndef message
+        fillMemoryList(it->second);
+    }
+    for (unsigned int i = 0; i != _memoryList.size(); i++)
+    {
+      int sector = _memoryList[i].byteAddr / 64;
+      int byte = _memoryList[i].byteAddr % 64;
+      int size = _memoryList[i].size;
+      if (bigBuffer.count(sector) > 0)
+      {
+        bigBuffer[sector].erase(bigBuffer[sector].begin() + byte, bigBuffer[sector].begin() + byte + size);
+      }
+    }
+    ByteVector finalBuffer;
+    for (auto c : bigBuffer)
+      finalBuffer.insert(finalBuffer.end(),c.second.begin(), c.second.end());
+    stock = NfcData::tlvToData(finalBuffer);
+    return stock;
+}
+
+std::shared_ptr<NdefMessage> MifareNFCTagCardService::readNDEF()
+{
+  return nullptr;
+}
+
+void MifareNFCTagCardService::writeNDEF(std::shared_ptr<NdefMessage> n)
+{
+
 }
 
 void MifareNFCTagCardService::eraseNDEF()
 {
-    // TODO: read MAD and format appropriate sector if setup?
+
+}
+
+void MifareNFCTagCardService::eraseNfc(std::shared_ptr<MifareKey> sectorKeyB, std::shared_ptr<MifareKey> madKeyB)
+{
+  MifareAccessInfo::SectorAccessBits sab;
+  std::shared_ptr<logicalaccess::MifareKey> factoryKey = std::make_shared<logicalaccess::MifareKey>("ff ff ff ff ff ff");
+
+
+  ByteVector madSector = getMifareChip()->getMifareCommands()->readSector(0, 1,std::make_shared<MifareKey>("a0 a1 a2 a3 a4 a5"), madKeyB, sab);
+  for (unsigned int i = 2; i + 1 < madSector.size(); i += 2)
+  {
+    if (madSector[i] == 0x03 && madSector[i + 1] == 0xE1)
+    {
+      eraseNfc(i / 2, sectorKeyB, madKeyB);
+    }
+  }
+}
+
+void MifareNFCTagCardService::eraseNfc(int sector, std::shared_ptr<MifareKey> sectorKeyB, std::shared_ptr<MifareKey> madKeyB)
+{
+  MifareAccessInfo::SectorAccessBits sab;
+  std::shared_ptr<logicalaccess::MifareKey> factoryKey = std::make_shared<logicalaccess::MifareKey>("ff ff ff ff ff ff");
+  ByteVector n;
+
+  n.resize(48);
+  std::fill(n.begin(), n.end(), 0);
+  ByteVector madSector = getMifareChip()->getMifareCommands()->readSector(0, 1,std::make_shared<MifareKey>("a0 a1 a2 a3 a4 a5"), madKeyB, sab);
+  if (sector * 2 + 1 < madSector.size() && madSector[sector * 2] == 0x03  &&  madSector[sector * 2 + 1] == 0xE1)
+  {
+    getMifareChip()->getMifareCommands()->changeKeys(logicalaccess::KT_KEY_B ,sectorKeyB, factoryKey, factoryKey, sector, &sab, 0x00);
+    getMifareChip()->getMifareCommands()->writeSector(sector, 0, n, factoryKey, factoryKey, sab);
+    madSector[sector * 2] = 0x00;
+    madSector[sector * 2 + 1] = 0x00;
+    unsigned char *buffer = new unsigned char[madSector.size()];
+    for (unsigned int i = 0; i < madSector.size() - 1; ++i)
+      buffer[i] = madSector[i + 1];
+    buffer[madSector.size() - 1] = 0;
+    int mad = getMifareChip()->getMifareCommands()->calculateMADCrc(buffer, madSector.size());
+    delete[] buffer;
+    madSector[0] = mad;
+    sab.setAReadBWriteConfiguration();
+    getMifareChip()->getMifareCommands()->writeSector(0, 1, madSector, std::make_shared<MifareKey>("a0 a1 a2 a3 a4 a5"), madKeyB, sab);
+  }
+}
+
+ByteVector MifareNFCTagCardService::getCardData()
+{
+  ByteVector data;
+  std::shared_ptr<MifareKey> key = std::make_shared<logicalaccess::MifareKey>("ff ff ff ff ff ff");
+  MifareAccessInfo::SectorAccessBits sab;
+  std::shared_ptr<MifareCommands> cmd = getMifareChip()->getMifareCommands();
+
+  data = cmd->readSectors(0, 15, 0, key, key, sab);
+  data.erase(data.begin(), data.begin() + 16);
+  return data;
+}
+
+void MifareNFCTagCardService::fillMemoryList(ByteVector data)
+{
+  size_t size =  data.size();
+  for (size_t i = 0; i != size && data[i] != 0x03; i++)
+  {
+    if (data[i] == 0x02 && i + 5 < size && data[i + 1]  == 3)
+    {
+      MemoryData md;
+      md.byteAddr = data[i + 2];
+      md.size = data[i + 3];
+      _memoryList.push_back(md);
+      i+=4;
+    }
+  }
+}
+
+int MifareNFCTagCardService::checkForReservedArea(unsigned int i)
+{
+  int res = -1;
+  unsigned int size = _memoryList.size();
+
+  for (unsigned int j = 0; j != size; j++)
+  {
+    if (i >= _memoryList[j].byteAddr && i < (_memoryList[j].byteAddr + _memoryList[j].size))
+    {
+      return _memoryList[j].byteAddr + _memoryList[j].size - i - 1;
+    }
+  }
+  return res;
 }
 }

--- a/plugins/logicalaccess/plugins/cards/mifare/mifarenfctagcardservice.hpp
+++ b/plugins/logicalaccess/plugins/cards/mifare/mifarenfctagcardservice.hpp
@@ -10,6 +10,8 @@
 #include <logicalaccess/services/nfctag/nfctagcardservice.hpp>
 #include <logicalaccess/services/nfctag/ndefmessage.hpp>
 #include <logicalaccess/plugins/cards/mifare/mifarechip.hpp>
+#include <logicalaccess/services/nfctag/memorycontroltlv.hpp>
+#include <logicalaccess/services/storage/storagecardservice.hpp>
 
 namespace logicalaccess
 {
@@ -45,11 +47,23 @@ class LLA_CARDS_MIFARE_API MifareNFCTagCardService : public NFCTagCardService
 
     void eraseNDEF() override;
 
+    void eraseNfc(std::shared_ptr<MifareKey> sectorKeyB = std::make_shared<MifareKey>("ff ff ff ff ff ff"), std::shared_ptr<MifareKey> madKeyB = std::make_shared<MifareKey>("ff ff ff ff ff ff"));
+    void eraseNfc(int sector, std::shared_ptr<MifareKey> sectorKeyB = std::make_shared<MifareKey>("ff ff ff ff ff ff"), std::shared_ptr<MifareKey> madKeyB = std::make_shared<MifareKey>("ff ff ff ff ff ff"));
+    std::vector<std::shared_ptr<NfcData> > readNFC();
+    std::vector<std::shared_ptr<NfcData> > readNFC(std::shared_ptr<AccessInfo> ai, unsigned int sector = 0);
+    void writeNFC(std::shared_ptr<NfcData> records, int sector, std::shared_ptr<AccessInfo> ai, MifareAccessInfo::SectorAccessBits madSab = MifareAccessInfo::SectorAccessBits());
+    void writeNFC(std::shared_ptr<NfcData> records,int sector, std::shared_ptr<MifareKey> keyA, std::shared_ptr<MifareKey> keyB, bool useMad = false);
+    void fillMemoryList(ByteVector data);
+    ByteVector getCardData();
+    int checkForReservedArea(unsigned int i);
   protected:
+    void writeInfo(int baseAddr, std::shared_ptr<MifareKey> keyB, ByteVector tmpBuff, bool useMad, std::shared_ptr<StorageCardService> storage);
+    void writeInfo(int baseAddr, std::shared_ptr<MifareAccessInfo> aiToWrite, ByteVector tmpBuffer, std::shared_ptr<StorageCardService> storage);
     std::shared_ptr<MifareChip> getMifareChip() const
     {
         return std::dynamic_pointer_cast<MifareChip>(getChip());
     }
+    std::vector<MemoryData> _memoryList;
 };
 }
 

--- a/plugins/logicalaccess/plugins/cards/mifare/mifarestoragecardservice.cpp
+++ b/plugins/logicalaccess/plugins/cards/mifare/mifarestoragecardservice.cpp
@@ -94,22 +94,17 @@ void MifareStorageCardService::writeData(std::shared_ptr<Location> location,
     std::shared_ptr<MifareLocation> mLocation =
         std::dynamic_pointer_cast<MifareLocation>(location);
     std::shared_ptr<MifareAccessInfo> mAiToUse =
-        std::dynamic_pointer_cast<MifareAccessInfo>(aiToUse);
-
+        std::dynamic_pointer_cast<MifareAccessInfo>(aiToWrite);
     EXCEPTION_ASSERT_WITH_LOG(mLocation, std::invalid_argument,
                               "location must be a MifareLocation.");
+
+
 
     if (aiToUse)
     {
         EXCEPTION_ASSERT_WITH_LOG(mAiToUse, std::invalid_argument,
                                   "aiToUse must be a MifareAccessInfo.");
     }
-    else
-    {
-        mAiToUse =
-            std::dynamic_pointer_cast<MifareAccessInfo>(getChip()->createAccessInfo());
-    }
-
     bool writeAidToMad = false;
 
     if (mLocation->useMAD)
@@ -161,7 +156,6 @@ void MifareStorageCardService::writeData(std::shared_ptr<Location> location,
                     mLocation->aid, i, mAiToUse->madKeyA, mAiToUse->madKeyB);
             }
         }
-
         std::shared_ptr<MifareAccessInfo> mAiToWrite;
         // Write access informations too
         if (aiToWrite)
@@ -206,7 +200,6 @@ void MifareStorageCardService::writeData(std::shared_ptr<Location> location,
                 mAiToWrite.reset();
             }
         }
-
         if (behaviorFlags & CB_AUTOSWITCHAREA)
         {
             getMifareChip()->getMifareCommands()->writeSectors(

--- a/plugins/logicalaccess/plugins/cards/mifareultralight/nfctag2cardservice.hpp
+++ b/plugins/logicalaccess/plugins/cards/mifareultralight/nfctag2cardservice.hpp
@@ -19,11 +19,6 @@ namespace logicalaccess
 /**
 * \brief The NFC Tag 2 storage card service base class.
 */
-struct MemoryData
-{
-  int byteAddr;
-  unsigned int size;
-};
 
 class LLA_CARDS_MIFAREULTRALIGHT_API NFCTag2CardService : public NFCTagCardService
 {

--- a/plugins/logicalaccess/plugins/readers/pcsc/commands/mifarepcsccommands.cpp
+++ b/plugins/logicalaccess/plugins/readers/pcsc/commands/mifarepcsccommands.cpp
@@ -161,10 +161,10 @@ ByteVector MifarePCSCCommands::readBinary(unsigned char blockno, size_t len)
     {
         THROW_EXCEPTION_WITH_LOG(std::invalid_argument, "Bad len parameter.");
     }
-
-    return getPCSCReaderCardAdapter()
-        ->sendAPDUCommand(0xFF, 0xB0, 0x00, blockno, static_cast<unsigned char>(len))
-        .getData();
+    ByteVector c;
+    c = getPCSCReaderCardAdapter()
+        ->sendAPDUCommand(0xFF, 0xB0, 0x00, blockno, static_cast<unsigned char>(len)).getData();
+    return c;
 }
 
 void MifarePCSCCommands::updateBinary(unsigned char blockno, const ByteVector &buf)

--- a/src/services/nfctag/memorycontroltlv.cpp
+++ b/src/services/nfctag/memorycontroltlv.cpp
@@ -54,7 +54,7 @@ namespace logicalaccess
     data->calculateReservedPosition();
     tlv.push_back((data->getPageAddr() << 4) + data->getOffset());
     tlv.push_back(data->getSize());
-    tlv.push_back((data->getBytesPerPage() << 4) + TLV_RFU);
+    tlv.push_back(data->getBytesPerPage());
     return tlv;
   }
 
@@ -65,15 +65,7 @@ namespace logicalaccess
     float bytesPerPage;
     float offset;
 
-    if (_byteAddr <= 64)
-    {
-      _bytesPerPage = 0x04;
-      _pageAddr = _byteAddr >> 4;
-      _offset = _byteAddr << 4;
-      _offset = _offset >> 4;
-      return ;
-    }
-    for (int i = 15; i >= 0; i--)
+    for (int i = 15; i > 0; i--)
     {
       a = ceil(_byteAddr / i);
       b = log2(a);


### PR DESCRIPTION
Now we can read and write ndef messages on Mifare Classic cards