### PR TITLE
Remove BinaryFieldValue

### DIFF
--- a/include/logicalaccess/services/accesscontrol/formats/customformat/binarydatafield.hpp
+++ b/include/logicalaccess/services/accesscontrol/formats/customformat/binarydatafield.hpp
@@ -8,88 +8,9 @@
 #define LOGICALACCESS_BINARYDATAFIELD_HPP
 
 #include <logicalaccess/services/accesscontrol/formats/customformat/valuedatafield.hpp>
-#include <logicalaccess/key.hpp>
 
 namespace logicalaccess
 {
-class LLA_CORE_API BinaryFieldValue : public Key
-{
-  public:
-    /**
-     * \brief Build an empty Binary field value.
-     */
-    BinaryFieldValue();
-
-    /**
-     * \brief Build a Binary field value given a string representation of it.
-     * \param str The string representation.
-     */
-    explicit BinaryFieldValue(const std::string &str);
-
-    /**
-     * \brief Build a Binary field value given a buffer.
-     * \param buf The buffer.
-     * \param buflen The buffer length.
-     */
-    explicit BinaryFieldValue(const ByteVector &buf);
-
-    virtual ~BinaryFieldValue() = default;
-    /**
-     * \brief Get the field length.
-     * \return The field length.
-     */
-    size_t getLength() const override
-    {
-        return d_buf.size();
-    }
-
-    /**
-     * \brief Get the key data.
-     * \return The key data.
-     */
-    const unsigned char *getData() const override
-    {
-        if (d_buf.size() != 0)
-            return &d_buf[0];
-        return nullptr;
-    }
-
-    /**
-     * \brief Get the key data.
-     * \return The key data.
-     */
-    unsigned char *getData() override
-    {
-        if (d_buf.size() != 0)
-            return &d_buf[0];
-        return nullptr;
-    }
-
-    /**
-     * \brief Serialize the current object to XML.
-     * \param parentNode The parent node.
-     */
-    void serialize(boost::property_tree::ptree &parentNode) override;
-
-    /**
-     * \brief UnSerialize a XML node to the current object.
-     * \param node The XML node.
-     */
-    void unSerialize(boost::property_tree::ptree &node) override;
-
-    /**
-     * \brief Get the default Xml Node name for this object.
-     * \return The Xml node name.
-     */
-    std::string getDefaultXmlNodeName() const override;
-
-  private:
-    /**
-     * \brief The key bytes;
-     */
-    ByteVector d_buf;
-};
-
 /**
  * \brief A binary data field.
  */
@@ -181,7 +102,7 @@ class LLA_CORE_API BinaryDataField : public ValueDataField
     std::string getDefaultXmlNodeName() const override;
 
   protected:
-    BinaryFieldValue d_value;
+    ByteVector d_buf;
 
     unsigned char d_padding;
 };


### PR DESCRIPTION
`BinaryFieldValue` seems to be a private data structure, and inherited Key only for `getString`/`fromString`, so I removed it completely, and added the required functionality using non-exposed functions in the cpp file.

This is a proposal for: https://github.com/islog/liblogicalaccess/issues/143

I kept the changes to the minimal, but if you want I can provide a unified implementation for `byteVectorToString`/`Key::toString` and `byteVectorFromString`/`Key::fromString`