### PR TITLE
SAMAV2ISO7816 command layer refactor

### DIFF
--- a/plugins/logicalaccess/plugins/cards/samav/samav2commands.hpp
+++ b/plugins/logicalaccess/plugins/cards/samav/samav2commands.hpp
@@ -19,21 +19,21 @@ template <typename T, typename S>
 class SAMAV2Commands : public ICommands
 {
   public:
-    virtual ByteVector dumpSecretKey(unsigned char keyno, unsigned char keyversion,
-                                     ByteVector divInput) = 0;
+    virtual ByteVector dumpSecretKey(unsigned char keyno, unsigned char keyversion, const ByteVector& divInput) = 0;
 
-    virtual void activateOfflineKey(unsigned char keyno, unsigned char keyversion,
-                                    ByteVector divInput) = 0;
+    virtual void activateOfflineKey(unsigned char keyno, unsigned char keyversion, const ByteVector& divInput) = 0;
 
-    virtual ByteVector decipherOfflineData(ByteVector data) = 0;
+    virtual ByteVector decipherOfflineData(const ByteVector &data) = 0;
 
-    virtual ByteVector encipherOfflineData(ByteVector data) = 0;
+    virtual ByteVector encipherOfflineData(const ByteVector &data) = 0;
 	
-    virtual void changeKeyEntryOffline(unsigned char keyno, const KeyEntryUpdateSettings& updateSettings, unsigned short changecnt, const ByteVector& encke) = 0;
+    virtual void changeKeyEntryOffline(unsigned char keyno, const KeyEntryUpdateSettings& updateSettings,
+        unsigned short changecnt, const ByteVector& encke) = 0;
 	
-    virtual void changeKUCEntryOffline(unsigned char kucno, const KucEntryUpdateSettings& updateSettings, unsigned short changecnt, const ByteVector& enckuc) = 0;
+    virtual void changeKUCEntryOffline(unsigned char kucno, const KucEntryUpdateSettings& updateSettings,
+        unsigned short changecnt, const ByteVector& enckuc) = 0;
 	
-    virtual void disableKeyEntryOffline(unsigned char keyno, unsigned short changecnt, const ByteVector& encuid)  = 0;
+    virtual void disableKeyEntryOffline(unsigned char keyno, unsigned short changecnt, const ByteVector& encuid) = 0;
 
     virtual void PKI_GenerateKeyPair(unsigned char keyNo, unsigned short configSettings, unsigned char keyNoCEK,
             unsigned char keyNoVCEK, unsigned char keyNoRef, const sam::AEKVAEK &accessKeys,
@@ -49,11 +49,9 @@ class SAMAV2Commands : public ICommands
                       const sam::AEKVAEK &accessKeys = {}, bool includeAccess = false,
                       bool updateSettingsOnly = false) = 0;
 
-    virtual ByteVector PKI_ExportPrivateKey(unsigned char keyNo,
-                                                bool returnAEK = false) = 0;
+    virtual ByteVector PKI_ExportPrivateKey(unsigned char keyNo, bool returnAEK = false) = 0;
 
-    virtual ByteVector PKI_ExportPublicKey(unsigned char keyNo,
-                                               bool returnAEK = false) = 0;
+    virtual ByteVector PKI_ExportPublicKey(unsigned char keyNo, bool returnAEK = false) = 0;
 
     virtual ByteVector PKI_UpdateKeyEntries(EVP_PKEY &encKey, EVP_PKEY &signKey,
                          unsigned char keyNoEnc, unsigned char keyNoSign, bool requestAck,
@@ -71,12 +69,9 @@ class SAMAV2Commands : public ICommands
             unsigned short persoCtr, const std::vector<std::pair<unsigned char, unsigned char>> &keyEntries,
             const ByteVector &divInput = {}) = 0;
 
-    virtual ByteVector PKI_GenerateHash(unsigned char hashAlgo,
-                                            const ByteVector &message) = 0;
+    virtual ByteVector PKI_GenerateHash(unsigned char hashAlgo, const ByteVector &message) = 0;
 
-    virtual void PKI_GenerateSignature(unsigned char hashAlgo,
-                                           unsigned char keyNoSign,
-                                           const ByteVector &hash) = 0;
+    virtual void PKI_GenerateSignature(unsigned char hashAlgo, unsigned char keyNoSign, const ByteVector &hash) = 0;
 
     virtual ByteVector PKI_SendSignature() = 0;
 

--- a/plugins/logicalaccess/plugins/cards/samav/samav2commands.hpp
+++ b/plugins/logicalaccess/plugins/cards/samav/samav2commands.hpp
@@ -37,7 +37,7 @@ class SAMAV2Commands : public ICommands
 
     virtual void PKI_GenerateKeyPair(unsigned char keyNo, unsigned short configSettings, unsigned char keyNoCEK,
             unsigned char keyNoVCEK, unsigned char keyNoRef, const sam::AEKVAEK &accessKeys,
-            unsigned short nLen = 0x40, const ByteVector &pki_e = {},
+            unsigned short nLen = 0x40, unsigned short eLen = 0x04, const ByteVector &pki_e = {},
             bool includeAccess = false) = 0;
 
     virtual void PKI_ImportKey(unsigned char keyNo, unsigned short configSettings,
@@ -53,7 +53,7 @@ class SAMAV2Commands : public ICommands
 
     virtual ByteVector PKI_ExportPublicKey(unsigned char keyNo, bool returnAEK = false) = 0;
 
-    virtual ByteVector PKI_UpdateKeyEntries(EVP_PKEY &encKey, EVP_PKEY &signKey,
+    virtual ByteVector PKI_UpdateKeyEntries(const ByteVector &encPublicKeyDer, const ByteVector &signPrivateKeyDer,
                          unsigned char keyNoEnc, unsigned char keyNoSign, bool requestAck,
                          unsigned char keyNoAck, unsigned char hashAlgo,
                          const std::vector<std::shared_ptr<SAMBasicKeyEntry>> &entries,

--- a/plugins/logicalaccess/plugins/cards/samav/samav3commands.hpp
+++ b/plugins/logicalaccess/plugins/cards/samav/samav3commands.hpp
@@ -31,15 +31,13 @@ class SAMAV3Commands : public ICommands
                                       bool settingsOnly          = false) = 0;
 
     virtual ByteVector PKI_ImportCaPkOffline(const ByteVector &offlineCryptogram,
-                                     bool settingsOnly, bool requestAck) = 0;
+                                     bool settingsOnly, bool expectResponseData) = 0;
 
     virtual void PKI_RemoveCaPk(const ByteVector &rid, unsigned char pkId) = 0;
 
-    virtual ByteVector PKI_RemoveCaPkOffline(const ByteVector &offlineCryptogram,
-                                             bool requestAck) = 0;
+    virtual ByteVector PKI_RemoveCaPkOffline(const ByteVector &offlineCryptogram, bool expectResponseData) = 0;
 
-    virtual ByteVector PKI_ExportCaPk(const ByteVector &rid, unsigned char pkId,
-                                      bool settingsOnly) = 0;
+    virtual ByteVector PKI_ExportCaPk(const ByteVector &rid, unsigned char pkId, bool settingsOnly) = 0;
 
     virtual ByteVector PKI_LoadIssuerPk(const ByteVector &rid, unsigned char pkId,
                                         const ByteVector &issuerPkCert,
@@ -54,8 +52,7 @@ class SAMAV3Commands : public ICommands
 
     virtual ByteVector SAM_RecoverDynamicData(const ByteVector &sdad) = 0;
 
-    virtual ByteVector SAM_EncipherPIN(const ByteVector &pinBlock,
-                                       const ByteVector &iccNumber) = 0;
+    virtual ByteVector SAM_EncipherPIN(const ByteVector &pinBlock, const ByteVector &iccNumber) = 0;
 };
 }
 

--- a/plugins/logicalaccess/plugins/cards/samav/samtypes.hpp
+++ b/plugins/logicalaccess/plugins/cards/samav/samtypes.hpp
@@ -11,25 +11,37 @@ namespace sam
 constexpr std::size_t MAX_APDU_DATA_SIZE = 0xFF;
 constexpr std::size_t SAM_SECURE_CHANNEL_MAX_PLAIN_LC = 0xF0;
 
+constexpr unsigned char AES_BLOCK_SIZE = 16;
+constexpr unsigned char STATUS_WORD_SIZE = 2;
+constexpr unsigned char MAC_SIZE = 8;
+
 // APDU format abstraction
 enum class ApduFormat : unsigned char
 {
-    Standard,      // short APDU (< 241 bytes)
-    Extended,      // extended APDU
-    ExtendedWithLe // extended APDU with Le
+    Standard,            // short APDU (< 241 bytes)
+    Extended,            // extended APDU
+    ExtendedWithLe,      // extended APDU with Le
+    ExtendedResponseOnly // extended APDU for responses only
 };
 
 // APDU result wrapper
-struct ApduResult
+struct ProtectedApdu
 {
     ByteVector encData;
     ByteVector mac;
     bool hasLe = false;
 };
 
+struct ApduInfo
+{
+    bool hasLc = false;
+    bool hasLe = false;
+};
+
 // Host communication mode
 enum class HostMode : unsigned char
 {
+    None        = 0xFF, // No host mode is active (host authentication not yet established)
     Plain       = 0x00,
     MAC         = 0x01,
     FullProtect = 0x02
@@ -70,8 +82,8 @@ struct ChainingLayout
 };
 
 // Predefined layouts
-static constexpr ChainingLayout PKI_ECC_LAYOUT = {2, 3};
-static constexpr ChainingLayout EMV_LAYOUT     = {3, 2};
+static constexpr ChainingLayout PKI_ECC_LAYOUT = {2, 3}; //PKI and ECC commands
+static constexpr ChainingLayout EMV_LAYOUT     = {3, 2}; //EMV commands
 
 // Optional AEK/VAEK (replaces pointers)
 struct AEKVAEK
@@ -110,9 +122,6 @@ inline void appendUInt16BE(ByteVector &out, uint16_t value)
 
 inline uint16_t parseStatusWord(const ByteVector &response)
 {
-    if (response.size() < 2)
-        return 0;
-
     return (static_cast<uint16_t>(response[response.size() - 2]) << 8) |
            static_cast<uint16_t>(response[response.size() - 1]);
 }
@@ -121,6 +130,86 @@ inline uint16_t parseStatusWord(const ByteVector &response)
 constexpr unsigned char toByte(HostMode mode)
 {
     return static_cast<unsigned char>(mode);
+}
+
+inline std::string errorMessage(const char *function, const std::string &message)
+{
+    return std::string(function) + " : " + message;
+}
+
+namespace pki
+{
+constexpr unsigned short ConfigDisableBit = 0x0004;
+}
+
+namespace sw
+{
+constexpr uint16_t Success = 0x9000;
+constexpr unsigned char SuccessSW1 = 0x90;
+constexpr unsigned char SuccessSW2  = 0x00;
+constexpr unsigned char MoreDataSW2 = 0xAF;
+}
+
+namespace ins
+{
+namespace host
+{
+constexpr unsigned char AuthenticateHost = 0xA4;
+}
+
+namespace key
+{
+constexpr unsigned char GetKeyEntry            = 0x64;
+constexpr unsigned char ChangeKeyEntry         = 0xC1;
+constexpr unsigned char DisableKeyEntryOffline = 0xD8;
+constexpr unsigned char EncipherKeyEntry       = 0xE1;
+constexpr unsigned char DumpSecretKey          = 0xD6;
+}
+
+namespace kuc
+{
+constexpr unsigned char GetEntry    = 0x6C;
+constexpr unsigned char ChangeEntry = 0xCC;
+}
+
+namespace offline
+{
+constexpr unsigned char ActivateKey  = 0x01;
+constexpr unsigned char DecipherData = 0x0D;
+constexpr unsigned char EncipherData = 0x0E;
+}
+
+namespace pki
+{
+constexpr unsigned char GenerateKeyPair    = 0x15;
+constexpr unsigned char ImportKey          = 0x19;
+constexpr unsigned char ExportPrivateKey   = 0x1F;
+constexpr unsigned char ExportPublicKey    = 0x18;
+constexpr unsigned char UpdateKeyEntries   = 0x1D;
+constexpr unsigned char EncipherKeyEntries = 0x12;
+constexpr unsigned char GenerateHash       = 0x17;
+constexpr unsigned char GenerateSignature  = 0x16;
+constexpr unsigned char SendSignature      = 0x1A;
+constexpr unsigned char VerifySignature    = 0x1B;
+constexpr unsigned char EncipherData       = 0x13;
+constexpr unsigned char DecipherData       = 0x14;
+constexpr unsigned char ImportECCKey       = 0x21;
+constexpr unsigned char ImportECCCurve     = 0x22;
+constexpr unsigned char ExportECCPublicKey = 0x23;
+constexpr unsigned char VerifyECCSignature = 0x20;
+}
+
+namespace emv
+{
+constexpr unsigned char ImportCaPk         = 0x24;
+constexpr unsigned char RemoveCaPk         = 0x2F;
+constexpr unsigned char ExportCaPk         = 0x3D;
+constexpr unsigned char LoadIssuerPk       = 0x27;
+constexpr unsigned char LoadIccPk          = 0x28;
+constexpr unsigned char RecoverStaticData  = 0x29;
+constexpr unsigned char RecoverDynamicData = 0x2A;
+constexpr unsigned char EncipherPin        = 0x2B;
+}
 }
 
 } // namespace sam

--- a/plugins/logicalaccess/plugins/cards/samav/samtypes.hpp
+++ b/plugins/logicalaccess/plugins/cards/samav/samtypes.hpp
@@ -1,27 +1,36 @@
 #ifndef LOGICALACCESS_SAMTYPES_HPP
 #define LOGICALACCESS_SAMTYPES_HPP
 
+#include <cstddef>
 #include <cstdint>
+#include <string>
 
 namespace logicalaccess
 {
 namespace sam
 {
 
-constexpr std::size_t MAX_APDU_DATA_SIZE = 0xFF;
-constexpr std::size_t SAM_SECURE_CHANNEL_MAX_PLAIN_LC = 0xF0;
+constexpr std::size_t APDU_COMMAND_HEADER_SIZE  = 0x04; // CLA INS P1 P2
+constexpr std::size_t APDU_HEADER_SIZE          = 0x05; // CLA INS P1 P2 Lc
+constexpr std::size_t APDU_HEADER_WITH_LE_SIZE  = APDU_HEADER_SIZE + 1u; // CLA INS P1 P2 Lc Le
+constexpr std::size_t APDU_LC_INDEX             = 0x04;
+constexpr std::size_t MAX_APDU_SIZE             = 0xFF;
+constexpr std::size_t MAX_APDU_PAYLOAD_SIZE     = MAX_APDU_SIZE - APDU_HEADER_SIZE;
+constexpr std::size_t MAX_SECURE_APDU_DATA_SIZE = 0xF0;
 
-constexpr unsigned char AES_BLOCK_SIZE = 16;
+constexpr unsigned char AES_BLOCK_SIZE   = 16;
+constexpr unsigned char AES_128_KEY_SIZE = 16;
+constexpr unsigned char AES_192_KEY_SIZE = 24;
+constexpr unsigned char AES_256_KEY_SIZE = 32;
 constexpr unsigned char STATUS_WORD_SIZE = 2;
-constexpr unsigned char MAC_SIZE = 8;
+constexpr unsigned char MAC_SIZE         = 8;
 
 // APDU format abstraction
 enum class ApduFormat : unsigned char
 {
-    Standard,            // short APDU (< 241 bytes)
-    Extended,            // extended APDU
-    ExtendedWithLe,      // extended APDU with Le
-    ExtendedResponseOnly // extended APDU for responses only
+    Standard,      // Single short APDU (command fits in one frame and payload is < 241 bytes when protected)
+    Extended,      // Command is transmitted over one or more extended APDUs (payload exceeds the Standard 240 bytes limit)
+    ExtendedWithLe // Same as Extended, with an Le field in the final APDU
 };
 
 // APDU result wrapper
@@ -56,14 +65,19 @@ enum class HashAlgo : unsigned char
     SHA256 = 0x03
 };
 
-constexpr bool isSupportedHashAlgo(unsigned char algo)
+constexpr bool isValidAESKeySize(std::size_t size) noexcept
+{
+    return size == AES_128_KEY_SIZE || size == AES_192_KEY_SIZE || size == AES_256_KEY_SIZE;
+}
+
+constexpr bool isSupportedHashAlgo(unsigned char algo) noexcept
 {
     return algo == static_cast<unsigned char>(HashAlgo::SHA1) ||
            algo == static_cast<unsigned char>(HashAlgo::SHA224) ||
            algo == static_cast<unsigned char>(HashAlgo::SHA256);
 }
 
-constexpr unsigned char expectedHashSize(unsigned char algo)
+constexpr unsigned char expectedHashSize(unsigned char algo) noexcept
 {
     switch (algo)
     {
@@ -77,24 +91,42 @@ constexpr unsigned char expectedHashSize(unsigned char algo)
 // APDU chaining layout
 struct ChainingLayout
 {
+    static constexpr unsigned char NoIndex = 0xFF;
+
     unsigned char modeIndex;
     unsigned char lastFrameIndex;
+
+    constexpr bool hasModeIndex() const noexcept
+    {
+        return modeIndex != NoIndex;
+    }
+
+    constexpr bool hasLastFrameIndex() const noexcept
+    {
+        return lastFrameIndex != NoIndex;
+    }
+
+    constexpr bool hasChaining() const noexcept
+    {
+        return hasModeIndex() && hasLastFrameIndex();
+    }
 };
 
 // Predefined layouts
-static constexpr ChainingLayout PKI_ECC_LAYOUT = {2, 3}; //PKI and ECC commands
-static constexpr ChainingLayout EMV_LAYOUT     = {3, 2}; //EMV commands
+static constexpr ChainingLayout PKI_ECC_LAYOUT = {2, 3}; // PKI and ECC commands
+static constexpr ChainingLayout EMV_LAYOUT     = {3, 2}; // EMV commands
+static constexpr ChainingLayout NO_LAYOUT      = {ChainingLayout::NoIndex, ChainingLayout::NoIndex};
 
 // Optional AEK/VAEK (replaces pointers)
 struct AEKVAEK
 {
-    uint8_t keyNoAEK = 0;
-    uint8_t keyVAEK  = 0;
+    unsigned char keyNoAEK = 0;
+    unsigned char keyVAEK  = 0;
     bool valid       = false;
 
     constexpr AEKVAEK() = default;
 
-    constexpr AEKVAEK(uint8_t aek, uint8_t vaek) : keyNoAEK(aek), keyVAEK(vaek), valid(true)
+    constexpr AEKVAEK(unsigned char aek, unsigned char vaek) : keyNoAEK(aek), keyVAEK(vaek), valid(true)
     {
 
     }
@@ -106,7 +138,7 @@ struct AEKVAEK
 };
 
 // Utility helpers
-inline void appendUInt32BE(ByteVector &out, uint32_t value)
+inline void appendUInt32BE(ByteVector &out, std::uint32_t value) noexcept
 {
     out.push_back(static_cast<unsigned char>((value >> 24) & 0xFF));
     out.push_back(static_cast<unsigned char>((value >> 16) & 0xFF));
@@ -114,20 +146,33 @@ inline void appendUInt32BE(ByteVector &out, uint32_t value)
     out.push_back(static_cast<unsigned char>(value & 0xFF));
 }
 
-inline void appendUInt16BE(ByteVector &out, uint16_t value)
+inline void appendUInt16BE(ByteVector &out, std::uint16_t value) noexcept
 {
     out.push_back(static_cast<unsigned char>((value >> 8) & 0xFF));
     out.push_back(static_cast<unsigned char>(value & 0xFF));
 }
 
-inline uint16_t parseStatusWord(const ByteVector &response)
+// TODO Replace with ISO7816Response once SAM commands migrate to that abstraction
+[[nodiscard]]
+inline bool tryParseStatusWord(const ByteVector &response, std::uint16_t &statusWord) noexcept
 {
-    return (static_cast<uint16_t>(response[response.size() - 2]) << 8) |
-           static_cast<uint16_t>(response[response.size() - 1]);
+    if (response.size() < STATUS_WORD_SIZE)
+        return false;
+
+    statusWord = (static_cast<std::uint16_t>(response[response.size() - STATUS_WORD_SIZE]) << 8) | response.back();
+
+    return true;
+}
+
+inline std::uint16_t parseStatusWord(const ByteVector &response) noexcept
+{
+    std::uint16_t sw = 0;
+    (void)tryParseStatusWord(response, sw);
+    return sw;
 }
 
 // Constants
-constexpr unsigned char toByte(HostMode mode)
+constexpr unsigned char toByte(HostMode mode) noexcept
 {
     return static_cast<unsigned char>(mode);
 }
@@ -144,10 +189,30 @@ constexpr unsigned short ConfigDisableBit = 0x0004;
 
 namespace sw
 {
-constexpr uint16_t Success = 0x9000;
 constexpr unsigned char SuccessSW1 = 0x90;
 constexpr unsigned char SuccessSW2  = 0x00;
 constexpr unsigned char MoreDataSW2 = 0xAF;
+}
+
+constexpr bool isSuccess(unsigned char sw1, unsigned char sw2) noexcept
+{
+    return sw1 == sw::SuccessSW1 && sw2 == sw::SuccessSW2;
+}
+
+constexpr bool hasMoreData(unsigned char sw1, unsigned char sw2) noexcept
+{
+    return sw1 == sw::SuccessSW1 && sw2 == sw::MoreDataSW2;
+}
+
+constexpr bool validState(unsigned char sw1, unsigned char sw2) noexcept
+{
+    return sw1 == sw::SuccessSW1 && (sw2 == sw::SuccessSW2 || sw2 == sw::MoreDataSW2);
+}
+
+namespace chaining
+{
+constexpr unsigned char Continue = sw::MoreDataSW2;
+constexpr unsigned char End      = sw::SuccessSW2;
 }
 
 namespace ins

--- a/plugins/logicalaccess/plugins/readers/iso7816/commands/samav1iso7816commands.hpp
+++ b/plugins/logicalaccess/plugins/readers/iso7816/commands/samav1iso7816commands.hpp
@@ -12,7 +12,6 @@
 #include <logicalaccess/plugins/readers/iso7816/commands/samiso7816commands.hpp>
 #include <logicalaccess/plugins/cards/samav/samcrypto.hpp>
 #include <logicalaccess/plugins/cards/samav/samkeyentry.hpp>
-#include <logicalaccess/plugins/cards/samav/samcrypto.hpp>
 #include <logicalaccess/plugins/cards/samav/samcommands.hpp>
 
 #include <boost/interprocess/mapped_region.hpp>

--- a/plugins/logicalaccess/plugins/readers/iso7816/commands/samav2iso7816commands.cpp
+++ b/plugins/logicalaccess/plugins/readers/iso7816/commands/samav2iso7816commands.cpp
@@ -20,6 +20,113 @@
 
 #include <cstring>
 
+#include <openssl/x509.h>
+
+namespace
+{
+using EVP_PKEY_ptr = std::unique_ptr<EVP_PKEY, decltype(&EVP_PKEY_free)>;
+
+EVP_PKEY_ptr loadPublicKeyFromDER(const ByteVector &der)
+{
+    EXCEPTION_ASSERT_WITH_LOG(!der.empty(), logicalaccess::LibLogicalAccessException,
+        logicalaccess::sam::errorMessage(__func__, "DER public key cannot be empty."));
+
+    const unsigned char *ptr = der.data();
+
+    EVP_PKEY *key = d2i_PUBKEY(nullptr, &ptr, static_cast<long>(der.size()));
+
+    EXCEPTION_ASSERT_WITH_LOG(key, logicalaccess::LibLogicalAccessException,
+        logicalaccess::sam::errorMessage(__func__, "Failed to parse DER public key."));
+
+    EXCEPTION_ASSERT_WITH_LOG(EVP_PKEY_base_id(key) == EVP_PKEY_RSA, logicalaccess::LibLogicalAccessException,
+        logicalaccess::sam::errorMessage(__func__, "Expected an RSA public key."));
+
+    EXCEPTION_ASSERT_WITH_LOG(ptr == der.data() + der.size(), logicalaccess::LibLogicalAccessException,
+        logicalaccess::sam::errorMessage(__func__, "Trailing bytes after DER public key."));
+
+    return EVP_PKEY_ptr(key, EVP_PKEY_free);
+}
+
+EVP_PKEY_ptr loadPrivateKeyFromDER(const ByteVector &der)
+{
+    EXCEPTION_ASSERT_WITH_LOG(!der.empty(), logicalaccess::LibLogicalAccessException,
+        logicalaccess::sam::errorMessage(__func__, "DER private key cannot be empty."));
+
+    const unsigned char *ptr = der.data();
+
+    EVP_PKEY *key = d2i_AutoPrivateKey(nullptr, &ptr, static_cast<long>(der.size()));
+
+    EXCEPTION_ASSERT_WITH_LOG(key, logicalaccess::LibLogicalAccessException,
+        logicalaccess::sam::errorMessage(__func__, "Failed to parse DER private key."));
+
+    EXCEPTION_ASSERT_WITH_LOG(EVP_PKEY_base_id(key) == EVP_PKEY_RSA, logicalaccess::LibLogicalAccessException,
+        logicalaccess::sam::errorMessage(__func__, "Expected an RSA private key."));
+
+    EXCEPTION_ASSERT_WITH_LOG(ptr == der.data() + der.size(), logicalaccess::LibLogicalAccessException,
+        logicalaccess::sam::errorMessage(__func__, "Trailing bytes after DER private key."));
+
+    return EVP_PKEY_ptr(key, EVP_PKEY_free);
+}
+
+using SessionVectorTags = std::array<std::array<unsigned char, 4>, 3>;
+
+constexpr SessionVectorTags ONLINE_SESSION_VECTOR_TAGS{{
+    {0x81, 0x00, 0x82, 0x00}, // AES 128
+    {0x83, 0x84, 0x85, 0x86}, // AES 192
+    {0x87, 0x88, 0x89, 0x8A}  // AES 256
+}};
+
+constexpr SessionVectorTags OFFLINE_SESSION_VECTOR_TAGS{{
+    {0x71, 0x00, 0x72, 0x00}, // AES 128
+    {0x73, 0x74, 0x75, 0x76}, // AES 192
+    {0x77, 0x78, 0x79, 0x7A}  // AES 256
+}};
+
+constexpr std::size_t keySizeIndex(std::size_t keySize)
+{
+    switch (keySize)
+    {
+    case logicalaccess::sam::AES_128_KEY_SIZE: return 0;
+    case logicalaccess::sam::AES_192_KEY_SIZE: return 1;
+    case logicalaccess::sam::AES_256_KEY_SIZE: return 2;
+    default:
+        THROW_EXCEPTION_WITH_LOG(logicalaccess::LibLogicalAccessException,
+            logicalaccess::sam::errorMessage(__func__, "Invalid AES key size."));
+    }
+}
+
+void secureZeroBuffer(ByteVector &buffer) noexcept
+{
+    if (!buffer.empty())
+        OPENSSL_cleanse(buffer.data(), buffer.size());
+}
+
+// RAII helper that securely erases temporary sensitive buffers when leaving scope, including during exception unwinding
+class SecureZeroGuard final
+{
+  public:
+    explicit SecureZeroGuard(std::initializer_list<ByteVector *> buffers)
+        : d_buffers(buffers.begin(), buffers.end())
+    {
+    }
+
+    ~SecureZeroGuard() noexcept
+    {
+        for (auto *buffer : d_buffers)
+            if (buffer != nullptr)
+                secureZeroBuffer(*buffer);
+    }
+
+    SecureZeroGuard(const SecureZeroGuard &)            = delete;
+    SecureZeroGuard &operator=(const SecureZeroGuard &) = delete;
+    SecureZeroGuard(SecureZeroGuard &&)            = delete;
+    SecureZeroGuard &operator=(SecureZeroGuard &&) = delete;
+  private:
+    std::vector<ByteVector *> d_buffers;
+};
+
+} // anonymous namespace
+
 namespace logicalaccess
 {
 SAMAV2ISO7816Commands::SAMAV2ISO7816Commands()
@@ -38,19 +145,22 @@ SAMAV2ISO7816Commands::SAMAV2ISO7816Commands(std::string ct)
 
 SAMAV2ISO7816Commands::~SAMAV2ISO7816Commands() {}
 
-void SAMAV2ISO7816Commands::generateSessionKey(ByteVector rnda, ByteVector rndb)
+void SAMAV2ISO7816Commands::generateSessionKey(const ByteVector &rnda, const ByteVector &rndb)
 {
-    constexpr size_t BLOCK_SIZE   = 16;
-    constexpr size_t AES_128_SIZE = 16;
-    constexpr size_t AES_192_SIZE = 24;
-    constexpr size_t AES_256_SIZE = 32;
+    EXCEPTION_ASSERT_WITH_LOG(rnda.size() == sam::AES_BLOCK_SIZE && rndb.size() == sam::AES_BLOCK_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid random number size."));
+    
+    constexpr std::size_t SESSION_VECTOR_TAG_INDEX = sam::AES_BLOCK_SIZE - 1;
 
-    ByteVector SV1a(BLOCK_SIZE), SV1b(BLOCK_SIZE), SV2a(BLOCK_SIZE), SV2b(BLOCK_SIZE),
-        emptyIV(BLOCK_SIZE, 0x00);
+    ByteVector SV1a(sam::AES_BLOCK_SIZE);
+    ByteVector SV1b(sam::AES_BLOCK_SIZE);
+    ByteVector SV2a(sam::AES_BLOCK_SIZE);
+    ByteVector SV2b(sam::AES_BLOCK_SIZE);
 
-    auto copy_block = [](ByteVector &dst, const ByteVector &src1, size_t off1,
-                         const ByteVector &src2, size_t off2, const ByteVector &src3,
-                         size_t off3)
+    SecureZeroGuard cleanup{&SV1a, &SV1b, &SV2a, &SV2b};
+
+    const auto copy_block = [](ByteVector &dst, const ByteVector &src1, std::size_t off1,
+                         const ByteVector &src2, std::size_t off2, const ByteVector &src3, std::size_t off3)
     {
         std::copy(src1.begin() + off1, src1.begin() + off1 + 5, dst.begin());
         std::copy(src2.begin() + off2, src2.begin() + off2 + 5, dst.begin() + 5);
@@ -58,155 +168,118 @@ void SAMAV2ISO7816Commands::generateSessionKey(ByteVector rnda, ByteVector rndb)
     };
 
     copy_block(SV1a, rnda, 11, rndb, 11, rnda, 4);
-    for (size_t x = 4; x <= 9; ++x)
+    for (std::size_t x = 4; x <= 9; ++x)
         SV1a[x + 6] ^= rndb[x];
 
     copy_block(SV1b, rnda, 10, rndb, 10, rnda, 5);
-    for (size_t x = 5; x <= 10; ++x)
+    for (std::size_t x = 5; x <= 10; ++x)
         SV1b[x + 5] ^= rndb[x];
 
     copy_block(SV2a, rnda, 7, rndb, 7, rnda, 0);
-    for (size_t x = 0; x <= 5; ++x)
+    for (std::size_t x = 0; x <= 5; ++x)
         SV2a[x + 10] ^= rndb[x];
 
     copy_block(SV2b, rnda, 6, rndb, 6, rnda, 1);
-    for (size_t x = 1; x <= 6; ++x)
+    for (std::size_t x = 1; x <= 6; ++x)
         SV2b[x + 9] ^= rndb[x];
 
-    size_t sessionKeySize = d_macSessionKey.size();
-    if (sessionKeySize != AES_128_SIZE && sessionKeySize != AES_192_SIZE && sessionKeySize != AES_256_SIZE)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-            sam::errorMessage(__func__, "Invalid session key size."));
+    const std::size_t aesKeySize = d_macSessionKey.size();
+    EXCEPTION_ASSERT_WITH_LOG(sam::isValidAESKeySize(aesKeySize),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid session key size."));
 
-    static constexpr std::array<std::array<unsigned char, 4>, 3> SV_TAGS = {{
-        {0x81, 0x00, 0x82, 0x00}, // AES 128
-        {0x83, 0x84, 0x85, 0x86}, // AES 192
-        {0x87, 0x88, 0x89, 0x8a}  // AES 256
-    }};
+    const auto &tags = ONLINE_SESSION_VECTOR_TAGS[keySizeIndex(aesKeySize)];
 
-    const size_t keyIndex = (sessionKeySize == AES_256_SIZE)   ? 2
-                            : (sessionKeySize == AES_192_SIZE) ? 1
-                                                               : 0;
-    const auto &sv_tags   = SV_TAGS[keyIndex];
+    SV1a[SESSION_VECTOR_TAG_INDEX] = tags[0];
+    SV1b[SESSION_VECTOR_TAG_INDEX] = tags[1];
+    SV2a[SESSION_VECTOR_TAG_INDEX] = tags[2];
+    SV2b[SESSION_VECTOR_TAG_INDEX] = tags[3];
 
-    SV1a[15] = sv_tags[0];
-    SV1b[15] = sv_tags[1];
-    SV2a[15] = sv_tags[2];
-    SV2b[15] = sv_tags[3];
-
-    auto symkey = openssl::AESSymmetricKey::createFromData(d_macSessionKey);
-    auto iv     = openssl::AESInitializationVector::createFromData(emptyIV);
-    openssl::AESCipher cipher;
-    ByteVector Kea, Keb, Kma, Kmb;
-
-    cipher.cipher(SV1a, Kea, symkey, iv, false);
-    cipher.cipher(SV1b, Keb, symkey, iv, false);
-    cipher.cipher(SV2a, Kma, symkey, iv, false);
-    cipher.cipher(SV2b, Kmb, symkey, iv, false);
-
-    d_sessionKey    = Kea;
-    d_macSessionKey = Kma;
-    if (sessionKeySize == AES_256_SIZE) /* AES 256 */
-    {
-        d_sessionKey.insert(d_sessionKey.end(), Keb.begin(), Keb.end());
-        d_macSessionKey.insert(d_macSessionKey.end(), Kmb.begin(), Kmb.end());
-    }
-    else if (sessionKeySize == AES_192_SIZE) /* AES 192 */
-    {
-        for (unsigned char x = 0; x < 8; ++x)
-        {
-            d_sessionKey[x + 8] ^= Keb[x];
-            d_macSessionKey[x + 8] ^= Kmb[x];
-        }
-        d_sessionKey.insert(d_sessionKey.end(), Keb.end() - 8, Keb.end());
-        d_macSessionKey.insert(d_macSessionKey.end(), Kmb.end() - 8, Kmb.end());
-    }
-    OPENSSL_cleanse(SV1a.data(), SV1a.size());
-    OPENSSL_cleanse(SV1b.data(), SV1b.size());
-    OPENSSL_cleanse(SV2a.data(), SV2a.size());
-    OPENSSL_cleanse(SV2b.data(), SV2b.size());
+    deriveSessionKeys(d_macSessionKey, SV1a, SV1b, SV2a, SV2b);
 }
 
-void SAMAV2ISO7816Commands::generateOfflineSessionKey(std::shared_ptr<DESFireKey> key,
-                                                      unsigned short changecnt)
+void SAMAV2ISO7816Commands::generateOfflineSessionKey(const std::shared_ptr<DESFireKey> &key, unsigned short changecnt)
 {
-    if (key->getKeyType() != DF_KEY_AES)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 sam::errorMessage(__func__, "Only AES Key allowed."));
+    EXCEPTION_ASSERT_WITH_LOG(key->getKeyType() == DF_KEY_AES,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Only AES Key allowed."));
 
-    constexpr size_t BLOCK_SIZE   = 16;
-    constexpr size_t AES_128_SIZE = 16;
-    constexpr size_t AES_192_SIZE = 24;
-    constexpr size_t AES_256_SIZE = 32;
-    const ByteVector keydata      = key->getData();
-    const size_t keysize          = keydata.size();
+    ByteVector keydata      = key->getData();
+    const std::size_t aesKeySize = keydata.size();
 
-    if (keysize != AES_128_SIZE && keysize != AES_192_SIZE && keysize != AES_256_SIZE)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 sam::errorMessage(__func__, "Invalid AES key size."));
+    EXCEPTION_ASSERT_WITH_LOG(sam::isValidAESKeySize(aesKeySize),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid AES key size."));
 
+    secureZero(d_sessionKey);
+    secureZero(d_macSessionKey);
     d_sessionKey.clear();
     d_macSessionKey.clear();
 
-    ByteVector SV1a, SV1b, SV2a, SV2b;
-    ByteVector emptyIV(BLOCK_SIZE, 0x00);
-    static constexpr std::array<std::array<unsigned char, 4>, 3> SV_TAGS = {{
-        {0x71, 0x00, 0x72, 0x00}, // AES 128
-        {0x73, 0x74, 0x75, 0x76}, // AES 192
-        {0x77, 0x78, 0x79, 0x7a}  // AES 256
-    }};
+    ByteVector SV1a(sam::AES_BLOCK_SIZE);
+    ByteVector SV1b(sam::AES_BLOCK_SIZE);
+    ByteVector SV2a(sam::AES_BLOCK_SIZE);
+    ByteVector SV2b(sam::AES_BLOCK_SIZE);
 
-    const size_t idx = (keysize == AES_192_SIZE) ? 1 : (keysize == AES_256_SIZE) ? 2 : 0;
-    const auto &t    = SV_TAGS[idx];
+    SecureZeroGuard cleanup{&keydata, &SV1a, &SV1b, &SV2a, &SV2b};
 
-    SV1a = SV1b = SV2a = SV2b = ByteVector(BLOCK_SIZE);
-    SV1a[0] = SV1b[0] = SV2a[0] = SV2b[0] =
-        static_cast<unsigned char>((changecnt >> 8) & 0xff);
+    const auto &tags = OFFLINE_SESSION_VECTOR_TAGS[keySizeIndex(aesKeySize)];
+
+    SV1a[0] = SV1b[0] = SV2a[0] = SV2b[0] = static_cast<unsigned char>((changecnt >> 8) & 0xff);
     SV1a[1] = SV1b[1] = SV2a[1] = SV2b[1] = static_cast<unsigned char>(changecnt & 0xff);
-    std::fill(SV1a.begin() + 2, SV1a.end(), t[0]);
-    std::fill(SV1b.begin() + 2, SV1b.end(), t[1]);
-    std::fill(SV2a.begin() + 2, SV2a.end(), t[2]);
-    std::fill(SV2b.begin() + 2, SV2b.end(), t[3]);
+    std::fill(SV1a.begin() + 2, SV1a.end(), tags[0]);
+    std::fill(SV1b.begin() + 2, SV1b.end(), tags[1]);
+    std::fill(SV2a.begin() + 2, SV2a.end(), tags[2]);
+    std::fill(SV2b.begin() + 2, SV2b.end(), tags[3]);
 
-    auto symkey = openssl::AESSymmetricKey::createFromData(keydata);
-    auto iv     = openssl::AESInitializationVector::createFromData(emptyIV);
+    deriveSessionKeys(keydata, SV1a, SV1b, SV2a, SV2b);
+}
+
+void SAMAV2ISO7816Commands::deriveSessionKeys(const ByteVector &masterKey, const ByteVector &SV1a, const ByteVector &SV1b,
+    const ByteVector &SV2a, const ByteVector &SV2b)
+{
+    auto symkey = openssl::AESSymmetricKey::createFromData(masterKey);
+    const auto iv = openssl::AESInitializationVector::createNull(); // emptyIV
+
     openssl::AESCipher cipher;
     ByteVector Kea, Keb, Kma, Kmb;
+
+    SecureZeroGuard cleanup{&Kea, &Keb, &Kma, &Kmb};
 
     cipher.cipher(SV1a, Kea, symkey, iv, false);
     cipher.cipher(SV1b, Keb, symkey, iv, false);
     cipher.cipher(SV2a, Kma, symkey, iv, false);
     cipher.cipher(SV2b, Kmb, symkey, iv, false);
 
-    d_sessionKey    = Kea;
-    d_macSessionKey = Kma;
-    if (keysize == AES_256_SIZE) /* AES 256 */
+    d_sessionKey = std::move(Kea);
+    d_macSessionKey = std::move(Kma);
+
+    mergeDerivedKeys(Keb, Kmb, masterKey.size());
+}
+
+void SAMAV2ISO7816Commands::mergeDerivedKeys(const ByteVector &sessionKeyExtension,
+    const ByteVector &macSessionKeyExtension, std::size_t keySize)
+{
+    if (keySize == sam::AES_256_KEY_SIZE) /* AES 256 */
     {
-        d_sessionKey.insert(d_sessionKey.end(), Keb.begin(), Keb.end());
-        d_macSessionKey.insert(d_macSessionKey.end(), Kmb.begin(), Kmb.end());
+        d_sessionKey.insert(d_sessionKey.end(), sessionKeyExtension.begin(), sessionKeyExtension.end());
+        d_macSessionKey.insert(d_macSessionKey.end(), macSessionKeyExtension.begin(), macSessionKeyExtension.end());
     }
-    else if (keysize == AES_192_SIZE) /* AES 192 */
+    else if (keySize == sam::AES_192_KEY_SIZE) /* AES 192 */
     {
-        for (unsigned char x = 0; x < 8; ++x)
+        for (std::size_t i = 0; i < 8; ++i)
         {
-            d_sessionKey[x + 8] ^= Keb[x];
-            d_macSessionKey[x + 8] ^= Kmb[x];
+            d_sessionKey[8 + i] ^= sessionKeyExtension[i];
+            d_macSessionKey[8 + i] ^= macSessionKeyExtension[i];
         }
-        d_sessionKey.insert(d_sessionKey.end(), Keb.end() - 8, Keb.end());
-        d_macSessionKey.insert(d_macSessionKey.end(), Kmb.end() - 8, Kmb.end());
+        d_sessionKey.insert(d_sessionKey.end(), sessionKeyExtension.end() - 8, sessionKeyExtension.end());
+        d_macSessionKey.insert(d_macSessionKey.end(), macSessionKeyExtension.end() - 8, macSessionKeyExtension.end());
     }
-    OPENSSL_cleanse(SV1a.data(), SV1a.size());
-    OPENSSL_cleanse(SV1b.data(), SV1b.size());
-    OPENSSL_cleanse(SV2a.data(), SV2a.size());
-    OPENSSL_cleanse(SV2b.data(), SV2b.size());
 }
 
 void SAMAV2ISO7816Commands::authenticateHost(std::shared_ptr<DESFireKey> key, unsigned char keyno)
 {
-    authenticateHost(key, keyno, sam::HostMode::FullProtect); // Host Mode: Full Protection
+    authenticateHost(key, keyno, sam::HostMode::FullProtect);
 }
 
-void SAMAV2ISO7816Commands::authenticateHost(std::shared_ptr<DESFireKey> key,
+void SAMAV2ISO7816Commands::authenticateHost(const std::shared_ptr<DESFireKey> &key,
                                              unsigned char keyno, sam::HostMode hostmode)
 {
     EXCEPTION_ASSERT_WITH_LOG(key != nullptr,
@@ -215,19 +288,34 @@ void SAMAV2ISO7816Commands::authenticateHost(std::shared_ptr<DESFireKey> key,
     EXCEPTION_ASSERT_WITH_LOG(key->getKeyType() == DF_KEY_AES,
         LibLogicalAccessException, sam::errorMessage(__func__, "Only AES Key allowed."));
 
-    constexpr unsigned char RND_SIZE = 12;
-    const unsigned char mode         = sam::toByte(hostmode);
+    constexpr std::size_t RND_SIZE = 12;
+
+    const unsigned char mode = sam::toByte(hostmode);
     const ByteVector emptyIV(sam::AES_BLOCK_SIZE, 0x00);
-    auto adapter       = getISO7816ReaderCardAdapter();
+    auto adapter = getISO7816ReaderCardAdapter();
     
-    const ByteVector keycipher = key->getData();
-    EXCEPTION_ASSERT_WITH_LOG(keycipher.size() == 16 || keycipher.size() == 24 || keycipher.size() == 32,
+    ByteVector keycipher = key->getData();
+    EXCEPTION_ASSERT_WITH_LOG(sam::isValidAESKeySize(keycipher.size()),
         LibLogicalAccessException, sam::errorMessage(__func__, "Invalid AES key size."));
 
-    /* Reset host authentication state. */
+    ByteVector rnd2;
+    ByteVector macHost;
+    ByteVector rnd1;
+    ByteVector data_p2;
+    ByteVector rndA;
+    ByteVector encRndB;
+    ByteVector dencRndB;
+    ByteVector rndB1;
+    ByteVector dataHost;
+    ByteVector encHost;
+    ByteVector SAMrndA;
+
+    SecureZeroGuard cleanup{&keycipher, &rnd2, &macHost, &rnd1, &data_p2, &rndA, &encRndB, &dencRndB,
+        &rndB1, &dataHost, &encHost, &SAMrndA};
+
+    /* Reset previous authentication state. */
     d_hostMode = sam::HostMode::None;
 
-    /* emptyIV and Clear Key */
     secureZero(d_sessionKey);
     secureZero(d_macSessionKey);
     d_lastMacIV     = emptyIV;
@@ -237,33 +325,30 @@ void SAMAV2ISO7816Commands::authenticateHost(std::shared_ptr<DESFireKey> key,
     auto result = adapter->sendAPDUCommand(d_cla, sam::ins::host::AuthenticateHost,
         0x00, 0x00, static_cast<unsigned char>(data_p1.size()), data_p1, 0x00);
 
-    EXCEPTION_ASSERT_WITH_LOG(result.getData().size() == 12 &&
-        result.getSW1() == sam::sw::SuccessSW1 && result.getSW2() == sam::sw::MoreDataSW2,
+    EXCEPTION_ASSERT_WITH_LOG(result.getData().size() == RND_SIZE && sam::hasMoreData(result.getSW1(), result.getSW2()),
         LibLogicalAccessException, sam::errorMessage(__func__, "P1 Failed."));
 
     d_macSessionKey = keycipher;
     auto cipher     = std::make_shared<openssl::AESCipher>();
 
     /* Create rnd2 for p3 - CMAC: rnd2 | Host Mode | ZeroPad */
-    ByteVector rnd2 = result.getData();
+    rnd2 = result.getData();
     rnd2.push_back(mode);
     rnd2.resize(sam::AES_BLOCK_SIZE, 0x00); // ZeroPad
 
-    ByteVector macHost = openssl::CMACCrypto::cmac(d_macSessionKey, cipher, rnd2, d_lastMacIV, sam::AES_BLOCK_SIZE);
+    macHost = openssl::CMACCrypto::cmac(d_macSessionKey, cipher, rnd2, d_lastMacIV, sam::AES_BLOCK_SIZE);
     truncateMacBuffer(macHost);
 
-    ByteVector rnd1(RND_SIZE);
+    rnd1.resize(RND_SIZE);
     EXCEPTION_ASSERT_WITH_LOG(RAND_bytes(rnd1.data(), static_cast<int>(rnd1.size())) == 1,
         LibLogicalAccessException, sam::errorMessage(__func__, "Cannot retrieve cryptographically strong bytes."));
 
-    ByteVector data_p2;
     data_p2.reserve(sam::MAC_SIZE + rnd1.size());
     data_p2.insert(data_p2.end(), macHost.begin(), macHost.begin() + sam::MAC_SIZE);
     data_p2.insert(data_p2.end(), rnd1.begin(), rnd1.end());
     result = adapter->sendAPDUCommand(d_cla, sam::ins::host::AuthenticateHost,
         0x00, 0x00, static_cast<unsigned char>(data_p2.size()), data_p2, 0x00);
-    EXCEPTION_ASSERT_WITH_LOG(result.getData().size() == 24 &&
-        result.getSW1() == sam::sw::SuccessSW1 && result.getSW2() == sam::sw::MoreDataSW2,
+    EXCEPTION_ASSERT_WITH_LOG(result.getData().size() == 24 && sam::hasMoreData(result.getSW1(), result.getSW2()),
         LibLogicalAccessException, sam::errorMessage(__func__, "P2 Failed."));
 
     /* Check CMAC - Create rnd1 for p3 - CMAC: rnd1 | P1 | other data */
@@ -276,7 +361,7 @@ void SAMAV2ISO7816Commands::authenticateHost(std::shared_ptr<DESFireKey> key,
     /* Create kxe - d_authKey */
     generateAuthEncKey(keycipher, rnd1, rnd2);
     // create rndA
-    ByteVector rndA(sam::AES_BLOCK_SIZE);
+    rndA.resize(sam::AES_BLOCK_SIZE);
     EXCEPTION_ASSERT_WITH_LOG(RAND_bytes(rndA.data(), static_cast<int>(rndA.size())) == 1,
         LibLogicalAccessException, sam::errorMessage(__func__, "Cannot retrieve cryptographically strong bytes."));
 
@@ -284,32 +369,26 @@ void SAMAV2ISO7816Commands::authenticateHost(std::shared_ptr<DESFireKey> key,
     auto symkey = openssl::AESSymmetricKey::createFromData(d_authKey);
     auto iv     = openssl::AESInitializationVector::createFromData(d_lastMacIV);
 
-    ByteVector encRndB(result.getData().begin() + sam::MAC_SIZE, result.getData().end());
-    ByteVector dencRndB;
+    encRndB.assign(result.getData().begin() + sam::MAC_SIZE, result.getData().end());
     cipher->decipher(encRndB, dencRndB, symkey, iv, false);
 
-    // create rndB'
-    ByteVector rndB1;
-    rndB1.insert(rndB1.begin(), dencRndB.begin() + 2, dencRndB.begin() + dencRndB.size());
-    rndB1.push_back(dencRndB[0]);
-    rndB1.push_back(dencRndB[1]);
+    // Rotate RndB : RndB' = RndB rotated by two bytes
+    rndB1.insert(rndB1.end(), dencRndB.begin() + 2, dencRndB.end());
+    rndB1.insert(rndB1.end(), dencRndB.begin(), dencRndB.begin() + 2);
 
-    ByteVector dataHost;
     dataHost.reserve(rndA.size() + rndB1.size());
     dataHost.insert(dataHost.end(), rndA.begin(), rndA.end());   // RndA
     dataHost.insert(dataHost.end(), rndB1.begin(), rndB1.end()); // RndB'
 
     iv = openssl::AESInitializationVector::createFromData(d_lastMacIV);
-    ByteVector encHost;
 
     cipher->cipher(dataHost, encHost, symkey, iv, false);
     result = adapter->sendAPDUCommand(d_cla, sam::ins::host::AuthenticateHost,
         0x00, 0x00, static_cast<unsigned char>(encHost.size()), encHost, 0x00);
     EXCEPTION_ASSERT_WITH_LOG(result.getData().size() == sam::AES_BLOCK_SIZE &&
-        result.getSW1() == sam::sw::SuccessSW1 && result.getSW2() == sam::sw::SuccessSW2,
+        sam::isSuccess(result.getSW1(), result.getSW2()),
         LibLogicalAccessException, sam::errorMessage(__func__, "P3 Failed."));
 
-    ByteVector SAMrndA;
     iv = openssl::AESInitializationVector::createFromData(d_lastMacIV);
     cipher->decipher(result.getData(), SAMrndA, symkey, iv, false);
     SAMrndA.insert(SAMrndA.begin(), SAMrndA.end() - 2, SAMrndA.end());
@@ -320,26 +399,14 @@ void SAMAV2ISO7816Commands::authenticateHost(std::shared_ptr<DESFireKey> key,
     generateSessionKey(rndA, dencRndB);
     d_cmdCtr = 0;
     d_hostMode = hostmode;
-
-    secureZero(rnd1);
-    secureZero(rnd2);
-    secureZero(rndA);
-    secureZero(dencRndB);
-    secureZero(rndB1);
-    secureZero(dataHost);
-    secureZero(encHost);
-    secureZero(encRndB);
-    secureZero(SAMrndA);
-    secureZero(macHost);
 }
 
 sam::ProtectedApdu SAMAV2ISO7816Commands::prepareProtectedApdu(const ByteVector &cmd, sam::ApduFormat format)
 {
-    if (cmd.size() < AV2_HEADER_LENGTH)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 sam::errorMessage(__func__, "Invalid command size."));
+    EXCEPTION_ASSERT_WITH_LOG(cmd.size() >= sam::APDU_HEADER_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid command size."));
 
-    ByteVector protectedCmd, encData;
+    ByteVector protectedCmd, protectedData;
 
     const auto apduInfo = getApduInfo(cmd, format);
     const bool encrypt = (d_hostMode == sam::HostMode::FullProtect);
@@ -347,48 +414,45 @@ sam::ProtectedApdu SAMAV2ISO7816Commands::prepareProtectedApdu(const ByteVector 
     if (!apduInfo.hasLc)
     {
         protectedCmd = cmd;
-        protectedCmd.insert(protectedCmd.begin() + AV2_LC_POS, sam::MAC_SIZE);
+        protectedCmd.insert(protectedCmd.begin() + sam::APDU_LC_INDEX, sam::MAC_SIZE);
     }
     else
     {
-        const size_t dataEnd = cmd.size() - (apduInfo.hasLe ? 1u : 0u);
-        ByteVector data(cmd.begin() + AV2_HEADER_LENGTH, cmd.begin() + dataEnd);
+        const std::size_t dataEnd = apduInfo.hasLe ? cmd.size() - 1 : cmd.size();
+        const ByteVector data(cmd.begin() + sam::APDU_HEADER_SIZE, cmd.begin() + dataEnd);
         if (encrypt)
         {
-            encData = encryptCommandData(data);
-            protectedCmd.insert(protectedCmd.end(), cmd.begin(), cmd.begin() + AV2_HEADER_LENGTH);
+            protectedData = encryptCommandData(data);
+            protectedCmd.assign(cmd.begin(), cmd.begin() + sam::APDU_HEADER_SIZE);
+            protectedCmd.insert(protectedCmd.end(), protectedData.begin(), protectedData.end());
             if (apduInfo.hasLe)
                 protectedCmd.push_back(cmd.back());
-            protectedCmd.insert(protectedCmd.begin() + AV2_HEADER_LENGTH, encData.begin(), encData.end());
-            protectedCmd[AV2_LC_POS] =
-                (encData.size() > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC) ? 0x00 : static_cast<unsigned char>(encData.size() + sam::MAC_SIZE);
         }
         else
         {
-            encData = data;
+            protectedData = data;
             protectedCmd = cmd;
-            const size_t dataLen = data.size();
-            protectedCmd[AV2_LC_POS] =
-                (dataLen > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC) ? 0x00 : static_cast<unsigned char>(dataLen + sam::MAC_SIZE);
         }
+        const std::size_t lcSize = protectedData.size();
+        protectedCmd[sam::APDU_LC_INDEX] = lcSize > sam::MAX_SECURE_APDU_DATA_SIZE ?
+            0x00 : static_cast<unsigned char>(lcSize + sam::MAC_SIZE);
     }
 
     /* Set counter */
     ByteVector cmdCtr;
-    cmdCtr.reserve(4);
-    BufferHelper::setUInt32(cmdCtr, d_cmdCtr);
-    std::reverse(cmdCtr.begin(), cmdCtr.end());
+    cmdCtr.reserve(sizeof(std::uint32_t));
+    sam::appendUInt32BE(cmdCtr, d_cmdCtr);
     protectedCmd.insert(protectedCmd.begin() + 2, cmdCtr.begin(), cmdCtr.end());
 
-    ByteVector macFull = computeCommandMac(protectedCmd);
+    const ByteVector mac = computeCommandMac(protectedCmd);
 
-    return {encData, macFull, apduInfo.hasLe};
+    return {protectedData, mac, apduInfo.hasLe};
 }
 
 ByteVector SAMAV2ISO7816Commands::computeCommandMac(ByteVector &protectedCmd)
 {
     const auto cipher = std::make_shared<openssl::AESCipher>();
-    const size_t blockReady = (protectedCmd.size() / sam::AES_BLOCK_SIZE) * sam::AES_BLOCK_SIZE;
+    const std::size_t blockReady = (protectedCmd.size() / sam::AES_BLOCK_SIZE) * sam::AES_BLOCK_SIZE;
     if (blockReady >= sam::AES_BLOCK_SIZE)
     {
         /* Encrypt complete blocks and preserve last MAC IV. */
@@ -429,34 +493,32 @@ ByteVector SAMAV2ISO7816Commands::encryptCommandData(const ByteVector &data)
 
 void SAMAV2ISO7816Commands::getLcLe(const ByteVector &cmd, bool &lc, bool &le)
 {
-    const size_t cmdSize = cmd.size();
+    const std::size_t commandSize = cmd.size();
 
-    EXCEPTION_ASSERT_WITH_LOG(cmdSize >= AV2_HEADER_LENGTH, LibLogicalAccessException,
+    EXCEPTION_ASSERT_WITH_LOG(commandSize >= sam::APDU_COMMAND_HEADER_SIZE, LibLogicalAccessException,
         sam::errorMessage(__func__, "APDU is shorter than the command header."));
 
     lc = false;
     le = false;
 
     // Command header only : [CLA INS P1 P2]
-    if (cmdSize == AV2_LC_POS)
+    if (commandSize == sam::APDU_COMMAND_HEADER_SIZE)
         return;
-    // Header only with Le : [CLA INS P1 P2 LE]
-    if (cmdSize == AV2_HEADER_LENGTH)
+    // Command header with Le : [CLA INS P1 P2 Le]
+    if (commandSize == sam::APDU_HEADER_SIZE)
     {
         le = true;
         return;
     }
-    const unsigned char lcByte = cmd[AV2_LC_POS];
-    const size_t expectedSizeWithLc = static_cast<size_t>(lcByte) + AV2_HEADER_LENGTH;
-    const size_t expectedSizeWithLcLe = static_cast<size_t>(lcByte) + AV2_HEADER_LENGTH_WITH_LE;
-    // Header, Lc and data : [CLA INS P1 P2 LC DATA]
-    if (cmdSize == expectedSizeWithLc)
+    const std::size_t lcSize = static_cast<std::size_t>(cmd[sam::APDU_LC_INDEX]);
+    // Command header, Lc and data : [CLA INS P1 P2 Lc Data]
+    if (commandSize == sam::APDU_HEADER_SIZE + lcSize)
     {
         lc = true;
         return;
     }
-    // Header, Lc, data and Le : [CLA INS P1 P2 LC DATA LE]
-    if (cmdSize == expectedSizeWithLcLe)
+    // Command header, Lc, data and Le : [CLA INS P1 P2 Lc Data Le]
+    if (commandSize == sam::APDU_HEADER_WITH_LE_SIZE + lcSize)
     {
         lc = true;
         le = true;
@@ -467,8 +529,8 @@ void SAMAV2ISO7816Commands::getLcLe(const ByteVector &cmd, bool &lc, bool &le)
 
 sam::ApduInfo SAMAV2ISO7816Commands::getApduInfo(const ByteVector &cmd, sam::ApduFormat format)
 {
-    sam::ApduInfo info;
-    if (format == sam::ApduFormat::Standard || format == sam::ApduFormat::ExtendedResponseOnly)
+    sam::ApduInfo info{};
+    if (format == sam::ApduFormat::Standard)
         getLcLe(cmd, info.hasLc, info.hasLe);
     else
     {
@@ -480,45 +542,53 @@ sam::ApduInfo SAMAV2ISO7816Commands::getApduInfo(const ByteVector &cmd, sam::Apd
 
 ByteVector SAMAV2ISO7816Commands::verifyAndDecryptResponse(const ByteVector &response)
 {
-    if (d_hostMode != sam::HostMode::MAC && d_hostMode != sam::HostMode::FullProtect)
-        THROW_EXCEPTION_WITH_LOG( LibLogicalAccessException,
-            sam::errorMessage(__func__, "Requires MAC or FullProtect host mode."));
+    EXCEPTION_ASSERT_WITH_LOG(d_hostMode == sam::HostMode::MAC || d_hostMode == sam::HostMode::FullProtect,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Requires MAC or FullProtect host mode."));
 
     /* begin check mac */
     if (response.size() < sam::MAC_SIZE + sam::STATUS_WORD_SIZE)
         return response;
 
+    constexpr std::size_t CMD_COUNTER_SIZE = sizeof(std::uint32_t);
+
     const auto cipher = std::make_shared<openssl::AESCipher>();
-    ByteVector mac(response.end() - sam::MAC_SIZE - sam::STATUS_WORD_SIZE, response.end() - sam::STATUS_WORD_SIZE);
+    const std::size_t payloadSize = response.size() - sam::MAC_SIZE - sam::STATUS_WORD_SIZE;
+    const auto swBegin    = response.end() - sam::STATUS_WORD_SIZE;
+    const bool hasPayload = (payloadSize != 0);
+
+    const ByteVector receivedMac(response.begin() + payloadSize, response.begin() + payloadSize + sam::MAC_SIZE);
 
     ByteVector macInput, cmdCtrVector, macCiphertext;
-    macInput.push_back(response[response.size() - 2]);
-    macInput.push_back(response[response.size() - 1]);
+    macInput.reserve(sam::STATUS_WORD_SIZE + CMD_COUNTER_SIZE + payloadSize);
+    macInput.insert(macInput.end(), swBegin, response.end());
 
     /* Set counter */
-    BufferHelper::setUInt32(cmdCtrVector, d_cmdCtr);
-    std::reverse(cmdCtrVector.begin(), cmdCtrVector.end());
+    cmdCtrVector.reserve(CMD_COUNTER_SIZE);
+    sam::appendUInt32BE(cmdCtrVector, d_cmdCtr);
     macInput.insert(macInput.end(), cmdCtrVector.begin(), cmdCtrVector.end());
 
-    const bool hasPayload = response.size() > sam::MAC_SIZE + sam::STATUS_WORD_SIZE;
     if (hasPayload)
     {
-        /* Encrypt complete MAC blocks and preserve chaining IV. */
-        auto symkeyMac = openssl::AESSymmetricKey::createFromData(d_macSessionKey);
-        auto ivMac     = openssl::AESInitializationVector::createFromData(d_lastMacIV);
-        macInput.insert(macInput.end(), response.begin(), response.end() - sam::MAC_SIZE - sam::STATUS_WORD_SIZE);
-        const size_t blockReady = (macInput.size() / sam::AES_BLOCK_SIZE) * sam::AES_BLOCK_SIZE;
-        ByteVector lastBlock(macInput.begin() + blockReady, macInput.end());
-        macInput.erase(macInput.begin() + blockReady, macInput.end());
-        cipher->cipher(macInput, macCiphertext, symkeyMac, ivMac, false);
-        d_lastMacIV.assign(macCiphertext.end() - sam::AES_BLOCK_SIZE, macCiphertext.end());
-        macInput = std::move(lastBlock);
+        macInput.insert(macInput.end(), response.begin(), response.begin() + payloadSize);
+        const std::size_t blockReady = (macInput.size() / sam::AES_BLOCK_SIZE) * sam::AES_BLOCK_SIZE;
+        if (blockReady != 0)
+        {
+            /* Encrypt complete MAC blocks and preserve chaining IV. */
+            const auto symkeyMac = openssl::AESSymmetricKey::createFromData(d_macSessionKey);
+            const auto ivMac = openssl::AESInitializationVector::createFromData(d_lastMacIV);
+            ByteVector lastBlock(macInput.begin() + blockReady, macInput.end());
+            macInput.erase(macInput.begin() + blockReady, macInput.end());
+            cipher->cipher(macInput, macCiphertext, symkeyMac, ivMac, false);
+            EXCEPTION_ASSERT_WITH_LOG(macCiphertext.size() >= sam::AES_BLOCK_SIZE,
+                LibLogicalAccessException, sam::errorMessage(__func__, "Cipher output error."));
+            d_lastMacIV.assign(macCiphertext.end() - sam::AES_BLOCK_SIZE, macCiphertext.end());
+            macInput = std::move(lastBlock);
+        }
     }
     macCiphertext = openssl::CMACCrypto::cmac(d_macSessionKey, cipher, macInput, d_lastMacIV, sam::AES_BLOCK_SIZE);
     truncateMacBuffer(macCiphertext);
-    if (!std::equal(macCiphertext.begin(), macCiphertext.begin() + sam::MAC_SIZE, mac.begin()))
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-            sam::errorMessage(__func__, "Response CMAC verification failed."));
+    EXCEPTION_ASSERT_WITH_LOG(std::equal(macCiphertext.begin(), macCiphertext.begin() + sam::MAC_SIZE, receivedMac.begin()),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Response CMAC verification failed."));
 
     ByteVector data;
     if (hasPayload)
@@ -527,10 +597,10 @@ ByteVector SAMAV2ISO7816Commands::verifyAndDecryptResponse(const ByteVector &res
         {
             /* begin decrypt */
             /* generate IV because first decrypt */
-            auto symkeySession = openssl::AESSymmetricKey::createFromData(d_sessionKey);
+            const auto symkeySession = openssl::AESSymmetricKey::createFromData(d_sessionKey);
             d_LastSessionIV = generateEncIV(false);
-            auto ivSession = openssl::AESInitializationVector::createFromData(d_LastSessionIV);
-            ByteVector encData(response.begin(), response.end() - sam::MAC_SIZE - sam::STATUS_WORD_SIZE);
+            const auto ivSession = openssl::AESInitializationVector::createFromData(d_LastSessionIV);
+            const ByteVector encData(response.begin(), response.begin() + payloadSize);
             cipher->decipher(encData, data, symkeySession, ivSession, false);
             int i = static_cast<int>(data.size()) - 1;
             while (i >= 0 && data[i] != 0x80 && data[i] == 0x00)
@@ -540,55 +610,53 @@ ByteVector SAMAV2ISO7816Commands::verifyAndDecryptResponse(const ByteVector &res
         }
         else
         {
-            data.assign(response.begin(), response.end() - sam::MAC_SIZE - sam::STATUS_WORD_SIZE);
+            data.assign(response.begin(), response.begin() + payloadSize);
         }
     }
-    const auto swOffset = response.size() - sam::STATUS_WORD_SIZE;
-    data.push_back(response[swOffset]);
-    data.push_back(response[swOffset + 1]);
+    data.insert(data.end(), swBegin, response.end());
     return data;
 }
 
 ByteVector SAMAV2ISO7816Commands::generateEncIV(bool encrypt) const
 {
-    constexpr size_t COUNTER_SIZE        = 4;
-    constexpr size_t PREFIX_SIZE         = 4;
-    constexpr size_t REPEAT_COUNT        = 3;
+    constexpr std::size_t COUNTER_SIZE   = 4;
+    constexpr std::size_t PREFIX_SIZE    = 4;
+    constexpr std::size_t REPEAT_COUNT   = 3;
     constexpr unsigned char FILL_ENCRYPT = 0x01;
     constexpr unsigned char FILL_DECRYPT = 0x02;
 
-    ByteVector myIV(PREFIX_SIZE + COUNTER_SIZE * REPEAT_COUNT);
+    ByteVector ivInput(PREFIX_SIZE + COUNTER_SIZE * REPEAT_COUNT);
 
     const unsigned char fill = encrypt ? FILL_ENCRYPT : FILL_DECRYPT;
-    std::fill(myIV.begin(), myIV.begin() + PREFIX_SIZE, fill);
+    std::fill(ivInput.begin(), ivInput.begin() + PREFIX_SIZE, fill);
 
-    ByteVector cmdCtrVector(COUNTER_SIZE);
-    BufferHelper::setUInt32(cmdCtrVector, d_cmdCtr);
-    std::reverse(cmdCtrVector.begin(), cmdCtrVector.end());
+    ByteVector cmdCtrVector;
+    cmdCtrVector.reserve(sizeof(std::uint32_t));
+    sam::appendUInt32BE(cmdCtrVector, d_cmdCtr);
 
-    for (size_t i = 0; i < REPEAT_COUNT; ++i)
+    for (std::size_t i = 0; i < REPEAT_COUNT; ++i)
         std::copy(cmdCtrVector.begin(), cmdCtrVector.end(),
-                  myIV.begin() + PREFIX_SIZE + (i * COUNTER_SIZE));
+                  ivInput.begin() + PREFIX_SIZE + (i * COUNTER_SIZE));
 
-    auto symkeyMac = openssl::AESSymmetricKey::createFromData(d_sessionKey);
-    auto iv        = openssl::AESInitializationVector::createFromData(d_LastSessionIV);
+    const auto symkeyMac = openssl::AESSymmetricKey::createFromData(d_sessionKey);
+    const auto iv = openssl::AESInitializationVector::createFromData(d_LastSessionIV);
     openssl::AESCipher cipher;
 
-    ByteVector encIV;
-    cipher.cipher(myIV, encIV, symkeyMac, iv, false);
+    ByteVector encryptedIV;
+    cipher.cipher(ivInput, encryptedIV, symkeyMac, iv, false);
 
-    return encIV;
+    return encryptedIV;
 }
 
 ByteVector SAMAV2ISO7816Commands::transmit(ByteVector cmd, bool first, bool last, bool s_mode)
 {
-    if (cmd.size() < AV2_HEADER_LENGTH)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "Invalid APDU : too short");
+    EXCEPTION_ASSERT_WITH_LOG(cmd.size() >= sam::APDU_COMMAND_HEADER_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid APDU : too short"));
 
     if (d_sessionKey.empty())
         return getISO7816ReaderCardAdapter()->sendCommand(cmd);
 
-    TransmissionOptions options {first || !s_mode, last || !s_mode, first, last, first || s_mode};
+    const TransmissionOptions options {first || !s_mode, last || !s_mode, first, last, first || s_mode};
     return executeProtectedExchange(cmd, sam::ApduFormat::Standard, sam::PKI_ECC_LAYOUT, options);
 }
 
@@ -598,18 +666,16 @@ void SAMAV2ISO7816Commands::resetIVs()
     secureZero(d_lastMacIV);
 }
 
-void SAMAV2ISO7816Commands::secureZero(ByteVector &vec)
+void SAMAV2ISO7816Commands::secureZero(ByteVector &buffer) noexcept
 {
-    if (!vec.empty())
-        OPENSSL_cleanse(vec.data(), vec.size());
+    secureZeroBuffer(buffer);
 }
 
 ByteVector SAMAV2ISO7816Commands::executeProtectedExchange(const ByteVector &cmd, sam::ApduFormat format,
     const sam::ChainingLayout &layout, const TransmissionOptions &options)
 {
-    if (cmd.size() < AV2_HEADER_LENGTH)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-            sam::errorMessage(__func__, "APDU is shorter than the command header."));
+    EXCEPTION_ASSERT_WITH_LOG(cmd.size() >= sam::APDU_COMMAND_HEADER_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "APDU is shorter than the command header."));
 
     try
     {
@@ -623,7 +689,7 @@ ByteVector SAMAV2ISO7816Commands::executeProtectedExchange(const ByteVector &cmd
         secureZero(d_macSessionKey);
         resetIVs();
         THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-            sam::errorMessage(__func__, std::string("SAM transmission failed: ") + e.what()));
+            sam::errorMessage(__func__, std::string("SAM transmission failed : ") + e.what()));
     }
 }
 
@@ -635,8 +701,9 @@ sam::ProtectedApdu SAMAV2ISO7816Commands::prepareProtectedCommand(const ByteVect
     case sam::HostMode::MAC:
     case sam::HostMode::FullProtect: return prepareProtectedApdu(cmd, format);
     case sam::HostMode::None:
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, sam::errorMessage(__func__,
-                                 "Host authentication has not been established."));
+    default:
+        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
+            sam::errorMessage(__func__, "Host authentication has not been established."));
     }
     THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, sam::errorMessage(__func__, "Invalid host mode."));
 }
@@ -655,7 +722,7 @@ ByteVector SAMAV2ISO7816Commands::completeSecureExchange(ByteVector response, co
         case sam::HostMode::MAC:
         case sam::HostMode::FullProtect:
             response = verifyAndDecryptResponse(std::move(response));
-            return response;
+            break;
         case sam::HostMode::None:
             THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
                 sam::errorMessage(__func__, "Host authentication has not been established."));
@@ -672,8 +739,15 @@ ByteVector SAMAV2ISO7816Commands::completeSecureExchange(ByteVector response, co
 std::vector<ByteVector> SAMAV2ISO7816Commands::createApduFrames(const ByteVector &cmd,
     const sam::ProtectedApdu &protection, sam::ApduFormat format, const sam::ChainingLayout &layout)
 {
-    if (cmd.size() < AV2_HEADER_LENGTH)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "Invalid APDU : too short");
+    EXCEPTION_ASSERT_WITH_LOG(cmd.size() >= sam::APDU_COMMAND_HEADER_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid APDU header."));
+
+    EXCEPTION_ASSERT_WITH_LOG(layout.hasModeIndex() == layout.hasLastFrameIndex(),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Incomplete APDU chaining layout."));
+
+    if (layout.hasChaining())
+        EXCEPTION_ASSERT_WITH_LOG(layout.modeIndex < sam::APDU_HEADER_SIZE && layout.lastFrameIndex < sam::APDU_HEADER_SIZE,
+            LibLogicalAccessException, sam::errorMessage(__func__, "Invalid APDU chaining layout."));
 
     switch (d_hostMode)
     {
@@ -685,139 +759,140 @@ std::vector<ByteVector> SAMAV2ISO7816Commands::createApduFrames(const ByteVector
             sam::errorMessage(__func__, "Host authentication has not been established."));
     }
 
-    THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                             sam::errorMessage(__func__, "Invalid host mode."));
+    THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, sam::errorMessage(__func__, "Invalid host mode."));
 }
 
 std::vector<ByteVector> SAMAV2ISO7816Commands::createSecureChainedApduFrames(
     const ByteVector &cmd, const sam::ProtectedApdu &protection, sam::ApduFormat format,
     const sam::ChainingLayout &layout)
 {
-    constexpr size_t MaxChunkSize = sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC;
+    
+    EXCEPTION_ASSERT_WITH_LOG(protection.mac.size() >= sam::MAC_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid MAC size."));
 
-    constexpr unsigned char MoreFrame = 0xAF;
-    constexpr unsigned char LastFrame = 0x00;
+    constexpr std::size_t maxChunkSize = sam::MAX_SECURE_APDU_DATA_SIZE;
+
+    const bool updateChainingFields = format != sam::ApduFormat::Standard && layout.hasChaining();
+
+    const auto &encData = protection.encData;
+    const auto &mac     = protection.mac;
+    const bool appendLe = protection.hasLe;
+
+    const std::size_t maxPayloadSize = sam::MAX_APDU_PAYLOAD_SIZE - (appendLe ? 1u : 0u);
+
+    const std::size_t frameCount = std::max<std::size_t>(1, (encData.size() + maxChunkSize - 1) / maxChunkSize);
+    std::vector<ByteVector> frames;
+    frames.reserve(frameCount);
 
     const unsigned char cla = cmd[0];
     const unsigned char ins = cmd[1];
     const unsigned char p1  = cmd[2];
     const unsigned char p2  = cmd[3];
 
-    const ByteVector &encData = protection.encData;
-    const ByteVector &mac     = protection.mac;
-    const bool le             = protection.hasLe;
-
-    EXCEPTION_ASSERT_WITH_LOG(mac.size() >= sam::MAC_SIZE, LibLogicalAccessException,
-        sam::errorMessage(__func__, "protected APDU MAC is shorter than expected."));
-
-    const size_t frameCount =
-        encData.empty() ? (format == sam::ApduFormat::ExtendedResponseOnly ? 1u : 0u)
-                        : (encData.size() + MaxChunkSize - 1) / MaxChunkSize;
-    std::vector<ByteVector> frames;
-    frames.reserve(frameCount);
-    auto buildFrame = [&](size_t offset, size_t chunkSize, bool isLastFrame) -> ByteVector
+    auto buildFrame = [&](std::size_t offset, std::size_t chunkSize, bool lastFrame) -> ByteVector
     {
         ByteVector frame;
-        frame.reserve(AV2_HEADER_LENGTH + chunkSize + (isLastFrame ? sam::MAC_SIZE : 0));
+        frame.reserve(sam::APDU_HEADER_SIZE + chunkSize +
+            (lastFrame ? sam::MAC_SIZE : 0u) + (appendLe && lastFrame ? 1u : 0u));
         frame.push_back(cla);
         frame.push_back(ins);
         frame.push_back(p1);
         frame.push_back(p2);
         frame.push_back(0x00);
-        const auto it = encData.begin() + offset;
-        frame.insert(frame.end(), it, it + chunkSize);
-        if (isLastFrame)
+        frame.insert(frame.end(), encData.begin() + offset, encData.begin() + offset + chunkSize);
+
+        if (lastFrame)
             frame.insert(frame.end(), mac.begin(), mac.begin() + sam::MAC_SIZE);
-        if (format != sam::ApduFormat::ExtendedResponseOnly)
+        if (updateChainingFields)
         {
-            frame[layout.lastFrameIndex] = isLastFrame ? LastFrame : MoreFrame;
-            if (offset > 0)
+            frame[layout.lastFrameIndex] = lastFrame ? sam::chaining::End : sam::chaining::Continue;
+            if (offset != 0)
                 frame[layout.modeIndex] = 0x00;
         }
-        const size_t lc = frame.size() - AV2_HEADER_LENGTH;
-        EXCEPTION_ASSERT_WITH_LOG(lc <= sam::MAX_APDU_DATA_SIZE, LibLogicalAccessException,
-            "APDU payload exceeds the maximum supported size.");
-        frame[AV2_LC_POS] = static_cast<unsigned char>(lc);
+        const std::size_t lc = frame.size() - sam::APDU_HEADER_SIZE;
+        EXCEPTION_ASSERT_WITH_LOG(lc <= maxPayloadSize,
+            LibLogicalAccessException, sam::errorMessage(__func__, "Secure APDU payload exceeds the maximum supported size."));
+        frame[sam::APDU_LC_INDEX] = static_cast<unsigned char>(lc);
         return frame;
     };
 
-    size_t offset = 0;
-    for (size_t frameIndex = 0; frameIndex < frameCount; ++frameIndex)
+    std::size_t offset = 0;
+    for (std::size_t frameIndex = 0; frameIndex < frameCount; ++frameIndex)
     {
-        const size_t remaining = encData.size() - offset;
-        const size_t chunkSize = (std::min)(MaxChunkSize, remaining);
-        const bool isLastFrame = (frameIndex + 1 == frameCount);
-        frames.emplace_back(buildFrame(offset, chunkSize, isLastFrame));
+        const std::size_t remaining = encData.size() - offset;
+        const std::size_t chunkSize = (std::min)(maxChunkSize, remaining);
+        const bool lastFrame = (frameIndex == frameCount - 1);
+        frames.emplace_back(buildFrame(offset, chunkSize, lastFrame));
         offset += chunkSize;
     }
 
-    if (le && !frames.empty())
+    if (appendLe && !frames.empty())
         frames.back().push_back(cmd.back());
 
     return frames;
 }
 
-//TODO merge parts of this function with createSecureChainedApduFrames
 std::vector<ByteVector> SAMAV2ISO7816Commands::createPlainChainedApduFrames(const ByteVector &cmd,
     sam::ApduFormat format, const sam::ChainingLayout &layout)
 {
-    constexpr size_t MaxChunkSize = sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC;
+    const auto apduInfo = getApduInfo(cmd, format);
 
-    constexpr unsigned char MoreFrame = 0xAF;
-    constexpr unsigned char LastFrame = 0x00;
-    
-    if (cmd.size() <= MaxChunkSize)
+    const std::size_t maxChunkSize = sam::MAX_APDU_PAYLOAD_SIZE - (apduInfo.hasLe ? 1u : 0u);
+
+    if (cmd.size() <= sam::MAX_APDU_SIZE)
         return {cmd};
 
-    const auto apduInfo    = getApduInfo(cmd, format);
-    const size_t dataBegin = apduInfo.hasLc ? AV2_HEADER_LENGTH : cmd.size(); //TODO optimize with cmd.size() <= MaxChunkSize
-    const size_t dataEnd   = cmd.size() - (apduInfo.hasLc ? 1u : 0u);
-    const size_t dataSize  = dataEnd - dataBegin;
+    const bool updateChainingFields = format != sam::ApduFormat::Standard && layout.hasChaining();
+
+    const std::size_t dataBegin = apduInfo.hasLc ? sam::APDU_HEADER_SIZE : cmd.size();
+    const std::size_t dataEnd = apduInfo.hasLc ? cmd.size() - (apduInfo.hasLe ? 1u : 0u) : cmd.size();
+    const std::size_t dataSize = dataEnd - dataBegin;
+
+    const std::size_t frameCount = std::max<std::size_t>(1, (dataSize + maxChunkSize - 1) / maxChunkSize);
+    std::vector<ByteVector> frames;
+    frames.reserve(frameCount);
 
     const unsigned char cla = cmd[0];
     const unsigned char ins = cmd[1];
     const unsigned char p1  = cmd[2];
     const unsigned char p2  = cmd[3];
 
-    bool first = true; //TODO Leave it like this for now but refactor it later
-
-    std::vector<ByteVector> frames;
-    frames.reserve((dataSize + MaxChunkSize - 1) / MaxChunkSize);
-    auto buildFrame = [&](size_t offset, size_t chunkSize, bool isLastFrame) -> ByteVector
+    auto buildFrame = [&](std::size_t offset, std::size_t chunkSize, bool lastFrame) -> ByteVector
     {
         ByteVector frame;
-        frame.reserve(AV2_HEADER_LENGTH + chunkSize + (isLastFrame && apduInfo.hasLe ? 1 : 0));
+        frame.reserve(sam::APDU_HEADER_SIZE + chunkSize + (lastFrame && apduInfo.hasLe ? 1u : 0u));
         frame.push_back(cla);
         frame.push_back(ins);
         frame.push_back(p1);
         frame.push_back(p2);
         frame.push_back(0x00);
-        auto it = cmd.begin() + offset;
-        frame.insert(frame.end(), it, it + chunkSize);
-        if (format != sam::ApduFormat::ExtendedResponseOnly)
+        frame.insert(frame.end(), cmd.begin() + dataBegin + offset, cmd.begin() + dataBegin + offset + chunkSize);
+        if (updateChainingFields)
         {
-            frame[layout.lastFrameIndex] = isLastFrame ? LastFrame : MoreFrame;
-            if (!first)
+            frame[layout.lastFrameIndex] = lastFrame ? sam::chaining::End : sam::chaining::Continue;
+            if (offset != 0)
                 frame[layout.modeIndex] = 0x00;
         }
-        const size_t lc = frame.size() - AV2_HEADER_LENGTH;
-        EXCEPTION_ASSERT_WITH_LOG(lc <= sam::MAX_APDU_DATA_SIZE, LibLogicalAccessException,
-            "APDU payload exceeds the maximum supported size.");
-        frame[AV2_LC_POS] = static_cast<unsigned char>(lc);
+        const std::size_t lc = frame.size() - sam::APDU_HEADER_SIZE;
+        EXCEPTION_ASSERT_WITH_LOG(lc <= maxChunkSize,
+            LibLogicalAccessException, sam::errorMessage(__func__, "APDU payload exceeds the maximum supported size."));
+        frame[sam::APDU_LC_INDEX] = static_cast<unsigned char>(lc);
         return frame;
     };
-    size_t offset = AV2_HEADER_LENGTH;
-    while (offset < dataSize)
+
+    std::size_t offset = 0;
+    for (std::size_t frameIndex = 0; frameIndex < frameCount; ++frameIndex)
     {
-        const size_t remaining = dataSize - offset;
-        const size_t chunkSize = (std::min)(MaxChunkSize, remaining);
-        const bool isLastFrame = (offset + chunkSize == dataSize);
-        frames.emplace_back(buildFrame(offset, chunkSize, isLastFrame));
+        const std::size_t remaining = dataSize - offset;
+        const std::size_t chunkSize = (std::min)(maxChunkSize, remaining);
+        const bool lastFrame = (frameIndex == frameCount - 1);
+        frames.emplace_back(buildFrame(offset, chunkSize, lastFrame));
         offset += chunkSize;
-        first = false;
     }
+
     if (apduInfo.hasLe && !frames.empty())
         frames.back().push_back(cmd.back());
+
     return frames;
 }
 
@@ -833,32 +908,32 @@ ByteVector SAMAV2ISO7816Commands::sendChainedFrames(const std::vector<ByteVector
     unsigned char sw1 = 0;
     unsigned char sw2 = 0;
 
-    auto appendResponse = [&](const ByteVector &r)
+    auto appendResponseData = [&](const ByteVector &apdu)
     {
-        EXCEPTION_ASSERT_WITH_LOG(r.size() >= sam::STATUS_WORD_SIZE,
-            LibLogicalAccessException, "APDU response does not contain a status word.");
-        const auto swOffset = r.size() - sam::STATUS_WORD_SIZE;
-        sw1 = r[swOffset];
-        sw2 = r[swOffset + 1];
-        response.insert(response.end(), r.begin(), r.end() - sam::STATUS_WORD_SIZE);
+        EXCEPTION_ASSERT_WITH_LOG(apdu.size() >= sam::STATUS_WORD_SIZE,
+            LibLogicalAccessException, sam::errorMessage(__func__, "APDU response does not contain a status word."));
+        const auto swBegin = apdu.end() - sam::STATUS_WORD_SIZE;
+        sw1 = swBegin[0];
+        sw2 = swBegin[1];
+        response.insert(response.end(), apdu.begin(), swBegin);
     };
 
-    for (size_t i = 0; i < frames.size(); ++i)
+    for (std::size_t i = 0; i < frames.size(); ++i)
     {
-        appendResponse(adapter->sendCommand(frames[i]));
-        const bool lastFrame = (i + 1 == frames.size());
-        if (!lastFrame && (sw1 != sam::sw::SuccessSW1 || sw2 != sam::sw::MoreDataSW2))
+        appendResponseData(adapter->sendCommand(frames[i]));
+        const bool lastFrame = (i == frames.size() - 1);
+        if (!lastFrame && !sam::hasMoreData(sw1, sw2))
             THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
                 sam::errorMessage(__func__, "Unexpected status word after intermediate chained frame."));
     }
-    while (sw1 == sam::sw::SuccessSW1 && sw2 == sam::sw::MoreDataSW2)
+    while (sam::hasMoreData(sw1, sw2))
     {
-        appendResponse(adapter->sendCommand(continueApdu));
-        if (sw1 != sam::sw::SuccessSW1 || (sw2 != sam::sw::SuccessSW2 && sw2 != sam::sw::MoreDataSW2))
+        appendResponseData(adapter->sendCommand(continueApdu));
+        if (!sam::validState(sw1, sw2))
             THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
                 sam::errorMessage(__func__, "Unexpected status word during response chaining."));
     }
-    if (sw1 != sam::sw::SuccessSW1 || sw2 != sam::sw::SuccessSW2)
+    if (!sam::isSuccess(sw1, sw2))
         THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, sam::errorMessage(__func__, "Expected 0x9000"));
     response.push_back(sw1);
     response.push_back(sw2);
@@ -867,20 +942,19 @@ ByteVector SAMAV2ISO7816Commands::sendChainedFrames(const std::vector<ByteVector
 
 void SAMAV2ISO7816Commands::validateSuccessResponse(const ByteVector &response, const char *caller) const
 {
-    EXCEPTION_ASSERT_WITH_LOG(response.size() >= sam::STATUS_WORD_SIZE, LibLogicalAccessException,
-        sam::errorMessage(caller, "APDU response does not contain a status word."));
+    std::uint16_t sw;
 
-    const size_t swOffset = response.size() - sam::STATUS_WORD_SIZE;
+    EXCEPTION_ASSERT_WITH_LOG(sam::tryParseStatusWord(response, sw),
+        LibLogicalAccessException, sam::errorMessage(caller, "APDU response does not contain a status word."));
 
-    EXCEPTION_ASSERT_WITH_LOG(response[swOffset] == sam::sw::SuccessSW1 && response[swOffset + 1] == sam::sw::SuccessSW2,
-                              LibLogicalAccessException, sam::errorMessage(caller, "Unexpected status word."));
+    EXCEPTION_ASSERT_WITH_LOG(sam::isSuccess(static_cast<unsigned char>(sw >> 8), static_cast<unsigned char>(sw & 0xFF)),
+        LibLogicalAccessException, sam::errorMessage(caller, "Unexpected status word."));
 }
 
-std::shared_ptr<SAMKeyEntry<KeyEntryAV2Information, SETAV2>>
-SAMAV2ISO7816Commands::getKeyEntry(unsigned char keyno)
+std::shared_ptr<SAMKeyEntry<KeyEntryAV2Information, SETAV2>> SAMAV2ISO7816Commands::getKeyEntry(unsigned char keyno)
 {
-    constexpr size_t EXPECTED_SIZE_MIN         = 14;
-    constexpr size_t EXPECTED_SIZE_MAX         = 15;
+    constexpr std::size_t EXPECTED_SIZE_MIN = 14;
+    constexpr std::size_t EXPECTED_SIZE_MAX = 15;
 
     unsigned char cmd[] = {d_cla, sam::ins::key::GetKeyEntry, keyno, 0x00, 0x00};
     ByteVector cmd_vector(cmd, cmd + 5);
@@ -891,7 +965,7 @@ SAMAV2ISO7816Commands::getKeyEntry(unsigned char keyno)
 
     validateSuccessResponse(result, __func__);
 
-    const size_t resultSize = result.size();
+    const std::size_t resultSize = result.size();
     KeyEntryAV2Information keyentryinformation;
     keyentryinformation.ExtSET = result[resultSize - 3];
     memcpy(keyentryinformation.set, &result[resultSize - 5], 2);
@@ -947,10 +1021,9 @@ void SAMAV2ISO7816Commands::changeKUCEntry(unsigned char kucno,
                                            std::shared_ptr<SAMKucEntry> kucEntry,
                                            std::shared_ptr<DESFireKey> /*key*/)
 {
-    if (d_sessionKey.size() == 0)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-            sam::errorMessage(__func__, "AuthenticationHost must be executed before calling this command."));
-
+    EXCEPTION_ASSERT_WITH_LOG(!d_sessionKey.empty(), LibLogicalAccessException,
+        sam::errorMessage(__func__, "AuthenticationHost must be executed before calling this command."));
+    
     const unsigned char lc = 0x06;
     const unsigned char cmd[] = {d_cla, sam::ins::kuc::ChangeEntry, kucno, kucEntry->getUpdateMask(), lc};
     ByteVector cmd_vector(cmd, cmd + 5);
@@ -967,18 +1040,16 @@ void SAMAV2ISO7816Commands::changeKeyEntry(unsigned char keyno,
     std::shared_ptr<SAMKeyEntry<KeyEntryAV2Information, SETAV2>> keyentry,
     std::shared_ptr<DESFireKey> /*key*/)
 {
-    if (d_sessionKey.size() == 0)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-            "Failed: AuthentificationHost have to be done before use such command.");
+    EXCEPTION_ASSERT_WITH_LOG(!d_sessionKey.empty(), LibLogicalAccessException,
+        sam::errorMessage(__func__, "Failed : AuthenticateHost has to be done before using this command."));
 
     const unsigned char proMas = keyentry->getUpdateMask();
 
-    size_t buffer_size  = SAM_KEY_BUFFER_SIZE + sizeof(KeyEntryAV2Information);
+    std::size_t buffer_size = SAM_KEY_BUFFER_SIZE + sizeof(KeyEntryAV2Information);
     unsigned char *data = new unsigned char[buffer_size]();
 
     memcpy(data, keyentry->getData(), SAM_KEY_BUFFER_SIZE);
-    memcpy(data + SAM_KEY_BUFFER_SIZE, &keyentry->getKeyEntryInformation(),
-           sizeof(KeyEntryAV2Information));
+    memcpy(data + SAM_KEY_BUFFER_SIZE, &keyentry->getKeyEntryInformation(), sizeof(KeyEntryAV2Information));
     ByteVector vectordata(data, data + buffer_size);
     delete[] data;
 
@@ -1046,12 +1117,12 @@ void SAMAV2ISO7816Commands::disableKeyEntryOffline(unsigned char keyno, unsigned
     validateSuccessResponse(result, __func__);
 }
 
-ByteVector SAMAV2ISO7816Commands::dumpSecretKey(unsigned char keyno, unsigned char keyversion, const ByteVector& divInput)
+ByteVector SAMAV2ISO7816Commands::dumpSecretKey(unsigned char keyno, unsigned char keyversion, const ByteVector &divInput)
 {
     const unsigned char p1 = divInput.empty() ? 0x00 : 0x02;
     const unsigned char lc = static_cast<unsigned char>(0x02 + divInput.size());
 
-    EXCEPTION_ASSERT_WITH_LOG(lc <= sam::MAX_APDU_DATA_SIZE, LibLogicalAccessException,
+    EXCEPTION_ASSERT_WITH_LOG(lc <= sam::MAX_SECURE_APDU_DATA_SIZE, LibLogicalAccessException,
         sam::errorMessage(__func__, "Diversification input is too large."));
 
     unsigned char cmd[] = {d_cla, sam::ins::key::DumpSecretKey, p1, 0x00, lc, keyno, keyversion, 0x00};
@@ -1064,7 +1135,7 @@ ByteVector SAMAV2ISO7816Commands::dumpSecretKey(unsigned char keyno, unsigned ch
     return ByteVector(result.begin(), result.end() - sam::STATUS_WORD_SIZE);
 }
 
-void SAMAV2ISO7816Commands::activateOfflineKey(unsigned char keyno, unsigned char keyversion, const ByteVector& divInput)
+void SAMAV2ISO7816Commands::activateOfflineKey(unsigned char keyno, unsigned char keyversion, const ByteVector &divInput)
 {
     const unsigned char p1 = static_cast<unsigned char>(divInput.size() > 0x00);
     const unsigned char lc = static_cast<unsigned char>(0x02 + divInput.size());
@@ -1174,21 +1245,24 @@ ByteVector SAMAV2ISO7816Commands::cmacOffline(const ByteVector &data)
 void SAMAV2ISO7816Commands::PKI_GenerateKeyPair(
     unsigned char keyNo, unsigned short configSettings, unsigned char keyNoCEK,
     unsigned char keyNoVCEK, unsigned char keyNoRef, const sam::AEKVAEK &accessKeys,
-    unsigned short nLen, const ByteVector &pki_e, bool includeAccess)
+    unsigned short nLen, unsigned short eLen, const ByteVector &pki_e, bool includeAccess)
 {
-    EXCEPTION_ASSERT_WITH_LOG(keyNo <= 0x01, LibLogicalAccessException,
-                              sam::errorMessage(__func__, "Invalid key number."));
+    EXCEPTION_ASSERT_WITH_LOG(keyNo <= 0x01,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid key number."));
 
     EXCEPTION_ASSERT_WITH_LOG(nLen >= 0x40 && nLen <= 0x100 && (nLen % 8) == 0,
         LibLogicalAccessException, sam::errorMessage(__func__, "Invalid RSA modulus length (nLen)."));
 
+    EXCEPTION_ASSERT_WITH_LOG(eLen >= 0x04 && eLen <= 0x100 && (eLen % 4) == 0 && eLen <= nLen,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid exponent length (eLen)."));
+
     const bool provideExponent = !pki_e.empty();
-    const unsigned short eLen = provideExponent ? static_cast<unsigned short>(pki_e.size()) : 0x04;
 
     if (provideExponent)
     {
-        EXCEPTION_ASSERT_WITH_LOG(eLen >= 0x04 && eLen <= 0x100 && (eLen % 4) == 0 && eLen <= nLen,
-            LibLogicalAccessException, sam::errorMessage(__func__, "Invalid exponent length (PKI_eLen)."));
+        EXCEPTION_ASSERT_WITH_LOG(static_cast<unsigned short>(pki_e.size()) == eLen,
+            LibLogicalAccessException, sam::errorMessage(__func__, "PKI_e length does not match PKI_eLen."));
+
         EXCEPTION_ASSERT_WITH_LOG((pki_e.back() & 0x01) != 0,
             LibLogicalAccessException, sam::errorMessage(__func__, "Exponent must be odd."));
     }
@@ -1203,8 +1277,11 @@ void SAMAV2ISO7816Commands::PKI_GenerateKeyPair(
 
     const unsigned char p1 = static_cast<unsigned char>(provideExponent ? 0x01 : 0x00) | (includeAccess ? 0x02 : 0x00);
 
+    constexpr std::size_t BASE_PAYLOAD_SIZE = 10;
+    constexpr std::size_t ACCESS_KEYS_SIZE  = 2;
+
     ByteVector payload;
-    payload.reserve((includeAccess ? 12 : 10) + pki_e.size());
+    payload.reserve(BASE_PAYLOAD_SIZE + (includeAccess ? ACCESS_KEYS_SIZE : 0u) + pki_e.size());
     payload.push_back(keyNo);
     sam::appendUInt16BE(payload, effectiveConfig);
     payload.push_back(keyNoCEK);
@@ -1221,7 +1298,7 @@ void SAMAV2ISO7816Commands::PKI_GenerateKeyPair(
         payload.insert(payload.end(), pki_e.begin(), pki_e.end());
 
     const unsigned char lc =
-        payload.size() > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC ? 0x00 : static_cast<unsigned char>(payload.size());
+        payload.size() > sam::MAX_SECURE_APDU_DATA_SIZE ? 0x00 : static_cast<unsigned char>(payload.size());
     ByteVector apdu{d_cla, sam::ins::pki::GenerateKeyPair, p1, 0x00, lc};
     apdu.insert(apdu.end(), payload.begin(), payload.end());
 
@@ -1236,18 +1313,29 @@ void SAMAV2ISO7816Commands::PKI_ImportKey(
     const ByteVector &pki_dP, const ByteVector &pki_dQ, const ByteVector &pki_ipq,
     const sam::AEKVAEK &accessKeys, bool includeAccess, bool updateSettingsOnly)
 {
-    const bool hasPrivateKey = !pki_p.empty();
+    const bool hasPrivateKey = !pki_p.empty() && !pki_q.empty() &&
+                                       !pki_dP.empty() && !pki_dQ.empty() && !pki_ipq.empty();
+    
+    const bool hasAnyPrivateComponent = !pki_p.empty() || !pki_q.empty() ||
+                                        !pki_dP.empty() || !pki_dQ.empty() || !pki_ipq.empty();
+
+    if (hasAnyPrivateComponent)
+        EXCEPTION_ASSERT_WITH_LOG(hasPrivateKey,
+            LibLogicalAccessException, sam::errorMessage(__func__, "Incomplete CRT key."));
 
     EXCEPTION_ASSERT_WITH_LOG(keyNo <= (hasPrivateKey ? 0x01 : 0x02),
         LibLogicalAccessException, sam::errorMessage(__func__, "Key number out of range."));
 
-    const size_t nLen = pki_n.size();
-    const size_t eLen = pki_e.size();
+    const std::size_t nLen = pki_n.size();
+    const std::size_t eLen = pki_e.size();
+    const std::size_t pLen = hasPrivateKey ? pki_p.size() : 0;
+    const std::size_t qLen = hasPrivateKey ? pki_q.size() : 0;
+
 
     if (!updateSettingsOnly)
     {
         EXCEPTION_ASSERT_WITH_LOG(!pki_n.empty() && !pki_e.empty(),
-            LibLogicalAccessException, sam::errorMessage(__func__, "Missing RSA components."));
+            LibLogicalAccessException, sam::errorMessage(__func__, "Missing RSA public key components."));
 
         EXCEPTION_ASSERT_WITH_LOG(nLen >= 0x40 && nLen <= 0x100 && (nLen % 8) == 0,
             LibLogicalAccessException, sam::errorMessage(__func__, "Invalid modulus length."));
@@ -1260,9 +1348,6 @@ void SAMAV2ISO7816Commands::PKI_ImportKey(
 
         EXCEPTION_ASSERT_WITH_LOG((pki_e.back() & 0x01) != 0,
             LibLogicalAccessException, sam::errorMessage(__func__, "Exponent must be odd."));
-
-        EXCEPTION_ASSERT_WITH_LOG(pki_n[0] != 0x00,
-            LibLogicalAccessException, sam::errorMessage(__func__, "Invalid modulus MSB."));
     }
 
     if (hasPrivateKey)
@@ -1270,27 +1355,32 @@ void SAMAV2ISO7816Commands::PKI_ImportKey(
         EXCEPTION_ASSERT_WITH_LOG(!pki_p.empty() && !pki_q.empty() && !pki_dP.empty() && !pki_dQ.empty() && !pki_ipq.empty(),
             LibLogicalAccessException, sam::errorMessage(__func__, "Incomplete CRT key."));
 
-        EXCEPTION_ASSERT_WITH_LOG(pki_dP.size() == pki_p.size(),
+        EXCEPTION_ASSERT_WITH_LOG(pLen >= 0x04 && pLen <= 0xF8,
+            LibLogicalAccessException, sam::errorMessage(__func__, "Invalid p length."));
+
+        EXCEPTION_ASSERT_WITH_LOG(qLen >= 0x04 && qLen <= 0xF8,
+            LibLogicalAccessException, sam::errorMessage(__func__, "Invalid q length."));
+
+        EXCEPTION_ASSERT_WITH_LOG(pki_dP.size() == pLen,
             LibLogicalAccessException, sam::errorMessage(__func__, "dP length mismatch (must equal p length)."));
 
-        EXCEPTION_ASSERT_WITH_LOG(pki_dQ.size() == pki_q.size(),
+        EXCEPTION_ASSERT_WITH_LOG(pki_dQ.size() == qLen,
             LibLogicalAccessException, sam::errorMessage(__func__, "dQ length mismatch (must equal q length)."));
 
-        EXCEPTION_ASSERT_WITH_LOG(pki_ipq.size() == pki_q.size(),
+        EXCEPTION_ASSERT_WITH_LOG(pki_ipq.size() == qLen,
             LibLogicalAccessException, sam::errorMessage(__func__, "ipq length mismatch (must equal q length)."));
 
         EXCEPTION_ASSERT_WITH_LOG(pki_p[0] != 0x00 && pki_q[0] != 0x00,
             LibLogicalAccessException, sam::errorMessage(__func__, "Invalid CRT prime MSB."));
 
-        const size_t nWords = (nLen + 3) / 4;
-        const size_t pWords = (pki_p.size() + 3) / 4;
-        const size_t qWords = (pki_q.size() + 3) / 4;
+        const std::size_t nWords = (nLen + 3) / 4;
+        const std::size_t pWords = (pLen + 3) / 4;
+        const std::size_t qWords = (qLen + 3) / 4;
 
         EXCEPTION_ASSERT_WITH_LOG(pWords + 2 <= nWords && qWords + 2 <= nWords,
             LibLogicalAccessException, sam::errorMessage(__func__, "Invalid CRT size relation."));
     }
 
-    const bool disableRequested    = (configSettings & 0x0004) != 0;
     unsigned short effectiveConfig = configSettings;
 
     if (includeAccess)
@@ -1303,9 +1393,11 @@ void SAMAV2ISO7816Commands::PKI_ImportKey(
         effectiveConfig &= static_cast<unsigned short>(~sam::pki::ConfigDisableBit);
     }
 
-    const unsigned char p1 = (updateSettingsOnly ? 0x01 : 0x00) | (includeAccess ? 0x02 : 0x00);
+    const unsigned char p1 = static_cast<unsigned char>((updateSettingsOnly ? 0x01 : 0x00) | (includeAccess ? 0x02 : 0x00));
 
     ByteVector payload;
+    payload.reserve(6 + (includeAccess ? 2 : 0) +
+        (!updateSettingsOnly ? 2 + nLen + 2 + eLen + (hasPrivateKey ? 2 + pLen + 2 + qLen + pLen + qLen + qLen : 0) : 0));
     payload.push_back(keyNo);
     sam::appendUInt16BE(payload, effectiveConfig);
     payload.push_back(keyNoCEK);
@@ -1322,10 +1414,8 @@ void SAMAV2ISO7816Commands::PKI_ImportKey(
         sam::appendUInt16BE(payload, static_cast<uint16_t>(eLen));
         if (hasPrivateKey)
         {
-            EXCEPTION_ASSERT_WITH_LOG(pki_p.size() <= 0xFFFF && pki_q.size() <= 0xFFFF,
-                                      LibLogicalAccessException, sam::errorMessage(__func__, "CRT size overflow."));
-            sam::appendUInt16BE(payload, static_cast<uint16_t>(pki_p.size()));
-            sam::appendUInt16BE(payload, static_cast<uint16_t>(pki_q.size()));
+            sam::appendUInt16BE(payload, static_cast<uint16_t>(pLen));
+            sam::appendUInt16BE(payload, static_cast<uint16_t>(qLen));
         }
         payload.insert(payload.end(), pki_n.begin(), pki_n.end());
         payload.insert(payload.end(), pki_e.begin(), pki_e.end());
@@ -1340,7 +1430,7 @@ void SAMAV2ISO7816Commands::PKI_ImportKey(
     }
 
     const unsigned char lc =
-        payload.size() > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC ? 0x00 : static_cast<unsigned char>(payload.size());
+        payload.size() > sam::MAX_SECURE_APDU_DATA_SIZE ? 0x00 : static_cast<unsigned char>(payload.size());
     ByteVector apdu{d_cla, sam::ins::pki::ImportKey, p1, 0x00, lc};
     apdu.insert(apdu.end(), payload.begin(), payload.end());
 
@@ -1355,7 +1445,7 @@ ByteVector SAMAV2ISO7816Commands::PKI_ExportPrivateKey(unsigned char keyNo, bool
 
     const unsigned char returnAekFlag = static_cast<unsigned char>(returnAEK ? 0x80 : 0x00);
     ByteVector apdu{d_cla, sam::ins::pki::ExportPrivateKey, keyNo, returnAekFlag, 0x00};
-    ByteVector response = executeProtectedExchange(apdu, sam::ApduFormat::ExtendedResponseOnly);
+    ByteVector response = executeProtectedExchange(apdu, sam::ApduFormat::Standard, sam::NO_LAYOUT);
     validateSuccessResponse(response, __func__);
 
     response.resize(response.size() - sam::STATUS_WORD_SIZE);
@@ -1369,39 +1459,39 @@ ByteVector SAMAV2ISO7816Commands::PKI_ExportPublicKey(unsigned char keyNo, bool 
 
     const unsigned char returnAekFlag = static_cast<unsigned char>(returnAEK ? 0x80 : 0x00);
     ByteVector apdu{d_cla, sam::ins::pki::ExportPublicKey, keyNo, returnAekFlag, 0x00};
-    ByteVector response = executeProtectedExchange(apdu, sam::ApduFormat::ExtendedResponseOnly);
+    ByteVector response = executeProtectedExchange(apdu, sam::ApduFormat::Standard, sam::NO_LAYOUT);
     validateSuccessResponse(response, __func__);
 
     response.resize(response.size() - sam::STATUS_WORD_SIZE);
     return response;
 }
 
-ByteVector SAMAV2ISO7816Commands::buildPlaintext(uint16_t changeCtr, const std::vector<std::shared_ptr<SAMBasicKeyEntry>> &entries)
+ByteVector SAMAV2ISO7816Commands::buildPlaintext(std::uint16_t changeCtr,
+    const std::vector<std::shared_ptr<SAMBasicKeyEntry>> &entries)
 {
+    constexpr std::size_t HEADER_SIZE = 2;
     ByteVector pt;
-
-    pt.push_back((changeCtr >> 8) & 0xFF);
-    pt.push_back(changeCtr & 0xFF);
+    pt.reserve(HEADER_SIZE + entries.size() * (2 + sizeof(KeyEntryAV2Information)));
+    sam::appendUInt16BE(pt, changeCtr);
 
     for (const auto &entry : entries)
     {
-        if (!entry)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "Null SAMBasicKeyEntry");
+        EXCEPTION_ASSERT_WITH_LOG(entry,
+            LibLogicalAccessException, sam::errorMessage(__func__, "Null SAMBasicKeyEntry."));
 
         //TODO : SAM must support both AV2 compatible (61 bytes) and AV3 (64 bytes) key entries
         auto *avEntry = dynamic_cast<SAMKeyEntry<KeyEntryAV2Information, SETAV2> *>(entry.get());
-        if (!avEntry)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "Entry is not a SAMKeyEntry AV2 type");
+        EXCEPTION_ASSERT_WITH_LOG(avEntry,
+            LibLogicalAccessException, sam::errorMessage(__func__, "Entry is not a SAMKeyEntry AV2 type."));
 
-        uint8_t keyNo  = avEntry->getKeyEntryInformation().desfirekeyno;
-        uint8_t proMas = entry->getUpdateMask();
+        const std::uint8_t keyNo = avEntry->getKeyEntryInformation().desfirekeyno;
+        const std::uint8_t updateMask = entry->getUpdateMask();
 
         const unsigned char *data = entry->getData();
-        size_t len                = entry->getLength();
+        const std::size_t len = entry->getLength();
 
         pt.push_back(keyNo);
-        pt.push_back(proMas);
+        pt.push_back(updateMask);
         pt.insert(pt.end(), data, data + len);
     }
     return pt;
@@ -1409,92 +1499,91 @@ ByteVector SAMAV2ISO7816Commands::buildPlaintext(uint16_t changeCtr, const std::
 
 ByteVector SAMAV2ISO7816Commands::rsa_oaep_encrypt(EVP_PKEY *pubKey, const ByteVector &plaintext, const EVP_MD *md)
 {
-    EVP_PKEY_CTX *ctx = EVP_PKEY_CTX_new(pubKey, nullptr);
-    if (!ctx)
-        throw std::runtime_error("CTX init failed");
+    EXCEPTION_ASSERT_WITH_LOG(pubKey,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Public key is null."));
 
-    if (EVP_PKEY_encrypt_init(ctx) <= 0)
-    {
-        EVP_PKEY_CTX_free(ctx);
-        throw std::runtime_error("encrypt_init failed");
-    }
+    EXCEPTION_ASSERT_WITH_LOG(md,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Hashing algorithm is null."));
 
-    if (EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_OAEP_PADDING) <= 0 ||
-        EVP_PKEY_CTX_set_rsa_oaep_md(ctx, md) <= 0 ||
-        EVP_PKEY_CTX_set_rsa_mgf1_md(ctx, md) <= 0)
-    {
-        EVP_PKEY_CTX_free(ctx);
-        throw std::runtime_error("OAEP parameter setup failed");
-    }
+    using EVP_PKEY_CTX_ptr = std::unique_ptr<EVP_PKEY_CTX, decltype(&EVP_PKEY_CTX_free)>;
 
-    size_t outLen = 0;
-    if (EVP_PKEY_encrypt(ctx, nullptr, &outLen, plaintext.data(), plaintext.size()) <= 0)
-    {
-        EVP_PKEY_CTX_free(ctx);
-        throw std::runtime_error("encrypt size calc failed");
-    }
+    EVP_PKEY_CTX_ptr ctx(EVP_PKEY_CTX_new(pubKey, nullptr), EVP_PKEY_CTX_free);
+
+    EXCEPTION_ASSERT_WITH_LOG(ctx,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Failed to create EVP_PKEY_CTX."));
+
+    EXCEPTION_ASSERT_WITH_LOG(EVP_PKEY_encrypt_init(ctx.get()) > 0,
+        LibLogicalAccessException, sam::errorMessage(__func__, "EVP_PKEY_encrypt_init failed."));
+
+    EXCEPTION_ASSERT_WITH_LOG(EVP_PKEY_CTX_set_rsa_padding(ctx.get(), RSA_PKCS1_OAEP_PADDING) > 0,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Failed to set RSA OAEP padding."));
+
+    EXCEPTION_ASSERT_WITH_LOG(EVP_PKEY_CTX_set_rsa_oaep_md(ctx.get(), md) > 0,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Failed to set OAEP hash algorithm."));
+
+    EXCEPTION_ASSERT_WITH_LOG(EVP_PKEY_CTX_set_rsa_mgf1_md(ctx.get(), md) > 0,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Failed to set MGF1 hash algorithm."));
+
+    std::size_t outLen = 0;
+
+    EXCEPTION_ASSERT_WITH_LOG(EVP_PKEY_encrypt(ctx.get(), nullptr, &outLen, plaintext.data(), plaintext.size()) > 0,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Failed to determine ciphertext length."));
 
     ByteVector out(outLen);
 
-    if (EVP_PKEY_encrypt(ctx, out.data(), &outLen, plaintext.data(), plaintext.size()) <=
-        0)
-    {
-        EVP_PKEY_CTX_free(ctx);
-        throw std::runtime_error("OAEP encrypt failed");
-    }
+    EXCEPTION_ASSERT_WITH_LOG(EVP_PKEY_encrypt(ctx.get(), out.data(), &outLen, plaintext.data(), plaintext.size()) > 0,
+        LibLogicalAccessException, sam::errorMessage(__func__, "RSA OAEP encryption failed."));
+
     out.resize(outLen);
-    EVP_PKEY_CTX_free(ctx);
     return out;
 }
 
-ByteVector SAMAV2ISO7816Commands::rsa_pss_sign(EVP_PKEY *privKey, const ByteVector &data,
-                                               const EVP_MD *md)
+ByteVector SAMAV2ISO7816Commands::rsa_pss_sign(EVP_PKEY *privKey, const ByteVector &data, const EVP_MD *md)
 {
-    EVP_MD_CTX *ctx = EVP_MD_CTX_new();
-    if (!ctx)
-        throw std::runtime_error("MD_CTX failed");
+    EXCEPTION_ASSERT_WITH_LOG(privKey,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Private key is null."));
 
-    EVP_PKEY_CTX *pkey_ctx = nullptr;
+    EXCEPTION_ASSERT_WITH_LOG(md,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Hashing algorithm is null."));
+    
+    using EVP_MD_CTX_ptr = std::unique_ptr<EVP_MD_CTX, decltype(&EVP_MD_CTX_free)>;
 
-    if (EVP_DigestSignInit(ctx, &pkey_ctx, md, nullptr, privKey) <= 0)
-    {
-        EVP_MD_CTX_free(ctx);
-        throw std::runtime_error("SignInit failed");
-    }
+    EVP_MD_CTX_ptr ctx(EVP_MD_CTX_new(), EVP_MD_CTX_free);
 
-    if (EVP_PKEY_CTX_set_rsa_padding(pkey_ctx, RSA_PKCS1_PSS_PADDING) <= 0 ||
-        EVP_PKEY_CTX_set_rsa_mgf1_md(pkey_ctx, md) <= 0 ||
-        EVP_PKEY_CTX_set_rsa_pss_saltlen(pkey_ctx, EVP_MD_size(md)) <= 0)
-    {
-        EVP_MD_CTX_free(ctx);
-        throw std::runtime_error("PSS config failed");
-    }
+    EXCEPTION_ASSERT_WITH_LOG(ctx,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Failed to create EVP_MD_CTX."));
 
-    if (EVP_DigestSignUpdate(ctx, data.data(), data.size()) <= 0)
-    {
-        EVP_MD_CTX_free(ctx);
-        throw std::runtime_error("SignUpdate failed");
-    }
+    EVP_PKEY_CTX *pkeyCtx = nullptr;
 
-    size_t sigLen = 0;
+    EXCEPTION_ASSERT_WITH_LOG(EVP_DigestSignInit(ctx.get(), &pkeyCtx, md, nullptr, privKey) > 0,
+        LibLogicalAccessException, sam::errorMessage(__func__, "EVP_DigestSignInit failed."));
 
-    if (EVP_DigestSignFinal(ctx, nullptr, &sigLen) <= 0)
-    {
-        EVP_MD_CTX_free(ctx);
-        throw std::runtime_error("Sign size calculation failed");
-    }
+    EXCEPTION_ASSERT_WITH_LOG(pkeyCtx,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Missing RSA signing context."));
+
+    EXCEPTION_ASSERT_WITH_LOG(EVP_PKEY_CTX_set_rsa_padding(pkeyCtx, RSA_PKCS1_PSS_PADDING) > 0,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Failed to set RSA PSS padding."));
+
+    EXCEPTION_ASSERT_WITH_LOG(EVP_PKEY_CTX_set_rsa_mgf1_md(pkeyCtx, md) > 0,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Failed to configure MGF1 hash algorithm."));
+
+    EXCEPTION_ASSERT_WITH_LOG(EVP_PKEY_CTX_set_rsa_pss_saltlen(pkeyCtx, EVP_MD_size(md)) > 0,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Failed to configure RSA PSS salt length."));
+
+    EXCEPTION_ASSERT_WITH_LOG(EVP_DigestSignUpdate(ctx.get(), data.data(), data.size()) > 0,
+        LibLogicalAccessException, sam::errorMessage(__func__, "EVP_DigestSignUpdate failed."));
+
+    std::size_t sigLen = 0;
+
+    EXCEPTION_ASSERT_WITH_LOG(EVP_DigestSignFinal(ctx.get(), nullptr, &sigLen) > 0,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Failed to determine signature length."));
 
     ByteVector sig(sigLen);
 
-    if (EVP_DigestSignFinal(ctx, sig.data(), &sigLen) <= 0)
-    {
-        EVP_MD_CTX_free(ctx);
-        throw std::runtime_error("Sign failed");
-    }
+    EXCEPTION_ASSERT_WITH_LOG(EVP_DigestSignFinal(ctx.get(), sig.data(), &sigLen) > 0,
+        LibLogicalAccessException, sam::errorMessage(__func__, "RSA PSS signature generation failed."));
 
     sig.resize(sigLen);
-    EVP_MD_CTX_free(ctx);
-
     return sig;
 }
 
@@ -1505,29 +1594,31 @@ const EVP_MD *SAMAV2ISO7816Commands::getHash(sam::HashAlgo hashAlgo)
     case sam::HashAlgo::SHA1: return EVP_sha1();
     case sam::HashAlgo::SHA224: return EVP_sha224();
     case sam::HashAlgo::SHA256: return EVP_sha256();
-    default: throw std::runtime_error("Invalid hash");
+    default:
+        EXCEPTION_ASSERT_WITH_LOG(false,
+            LibLogicalAccessException, sam::errorMessage(__func__, "Unsupported hash algorithm."));
     }
+    return nullptr; // Unreachable but avoids compiler warning
 }
 
 void SAMAV2ISO7816Commands::buildCryptogram(
-    EVP_PKEY *encKey, EVP_PKEY *signKey, uint8_t keyNoEnc, uint8_t keyNoSign,
-    uint16_t changeCtr, const std::vector<std::shared_ptr<SAMBasicKeyEntry>> &entries,
-    uint8_t hashAlgo, ByteVector &encFrame, ByteVector &signature)
+    EVP_PKEY *encKey, EVP_PKEY *signKey, std::uint8_t keyNoEnc, std::uint8_t keyNoSign,
+    std::uint16_t changeCtr, const std::vector<std::shared_ptr<SAMBasicKeyEntry>> &entries,
+    std::uint8_t hashAlgo, ByteVector &encFrame, ByteVector &signature)
 {
-    if (!sam::isSupportedHashAlgo(hashAlgo))
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_UpdateKeyEntries : unsupported or RFU hash algorithm.");
+    EXCEPTION_ASSERT_WITH_LOG(sam::isSupportedHashAlgo(hashAlgo),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Unsupported or RFU hash algorithm."));
 
     const EVP_MD *md = getHash(static_cast<sam::HashAlgo>(hashAlgo));
 
-    if (!md)
-        throw std::runtime_error("Invalid hash algorithm");
+    EXCEPTION_ASSERT_WITH_LOG(md,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Failed to resolve hash algorithm."));
 
     // plaintext
-    ByteVector pt = buildPlaintext(changeCtr, entries);
+    ByteVector plaintext = buildPlaintext(changeCtr, entries);
 
     // encryption
-    encFrame = rsa_oaep_encrypt(encKey, pt, md);
+    encFrame = rsa_oaep_encrypt(encKey, plaintext, md);
 
     // signature
     ByteVector toSign;
@@ -1539,29 +1630,23 @@ void SAMAV2ISO7816Commands::buildCryptogram(
 }
 
 ByteVector SAMAV2ISO7816Commands::PKI_UpdateKeyEntries(
-    EVP_PKEY &encKey, EVP_PKEY &signKey, unsigned char keyNoEnc, unsigned char keyNoSign,
-    bool requestAck, unsigned char keyNoAck, unsigned char hashAlgo,
-    const std::vector<std::shared_ptr<SAMBasicKeyEntry>> &entries, uint16_t changeCounter)
+    const ByteVector &encPublicKeyDer, const ByteVector &signPrivateKeyDer, unsigned char keyNoEnc,
+    unsigned char keyNoSign, bool requestAck, unsigned char keyNoAck, unsigned char hashAlgo,
+    const std::vector<std::shared_ptr<SAMBasicKeyEntry>> &entries, std::uint16_t changeCounter)
 {
-    if (entries.empty() || entries.size() > 3)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_UpdateKeyEntries : invalid number of entries");
+    EXCEPTION_ASSERT_WITH_LOG(!entries.empty() && entries.size() <= 3,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid number of entries."));
 
-    EVP_PKEY *enc = &encKey;  //To avoid pointer as arg
-    EVP_PKEY *sig = &signKey; //To avoid pointer as arg
+    auto encKey  = loadPublicKeyFromDER(encPublicKeyDer);
+    auto signKey = loadPrivateKeyFromDER(signPrivateKeyDer);
 
-    if (!enc || !sig)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "Invalid ENC or SIGN key");
-
-    ByteVector encFrame;
+    ByteVector encryptedFrame;
     ByteVector signature;
 
-    buildCryptogram(enc, sig, keyNoEnc, keyNoSign, changeCounter, entries,
-                    hashAlgo, encFrame, signature);
+    buildCryptogram(encKey.get(), signKey.get(), keyNoEnc, keyNoSign, changeCounter, entries, hashAlgo, encryptedFrame, signature);
 
     return PKI_UpdateKeyEntries(keyNoEnc, keyNoSign, requestAck, keyNoAck, hashAlgo,
-                                static_cast<unsigned char>(entries.size()), encFrame,
-                                signature);
+                                static_cast<unsigned char>(entries.size()), encryptedFrame, signature);
 }
 
 ByteVector SAMAV2ISO7816Commands::PKI_UpdateKeyEntries(
@@ -1569,36 +1654,37 @@ ByteVector SAMAV2ISO7816Commands::PKI_UpdateKeyEntries(
     unsigned char hashAlgo, unsigned char nbKeyEntries, const ByteVector &encKeyFrame,
     const ByteVector &signature)
 {
-    if (hashAlgo > 0x03)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_UpdateKeyEntries : invalid hashAlgo (must be 0...3)");
+    constexpr unsigned char MAX_HASH_ALGO   = 0x03;
+    constexpr unsigned char MAX_KEY_ENTRIES = 0x03;
+    constexpr unsigned char MAX_ENC_KEY_NO  = 0x01;
+    constexpr unsigned char MAX_SIGN_KEY_NO = 0x02;
+    constexpr unsigned char MAX_ACK_KEY_NO  = 0x01;
 
-    if (nbKeyEntries == 0 || nbKeyEntries > 3)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_UpdateKeyEntries : invalid nbKeys (must be 1...3)");
+    EXCEPTION_ASSERT_WITH_LOG(hashAlgo <= MAX_HASH_ALGO,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid hash algorithm (must be 0...3)."));
 
-    if (keyNoEnc > 0x01)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_UpdateKeyEntries : invalid keyNoEnc.");
-    
-    if (keyNoSign > 0x02)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_UpdateKeyEntries : invalid keyNoSign.");
-    
-    if (requestAck && keyNoAck > 0x01)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_UpdateKeyEntries : invalid keyNoAck.");
+    EXCEPTION_ASSERT_WITH_LOG(nbKeyEntries >= 1 && nbKeyEntries <= MAX_KEY_ENTRIES,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid number of key entries (must be 1...3)."));
 
-    if (encKeyFrame.empty())
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_UpdateKeyEntries : encKeyFrame cannot be empty");
+    EXCEPTION_ASSERT_WITH_LOG(keyNoEnc <= MAX_ENC_KEY_NO,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid encryption key number."));
 
-    if (signature.empty())
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "PKI_UpdateKeyEntries : signature cannot be empty");
+    EXCEPTION_ASSERT_WITH_LOG(keyNoSign <= MAX_SIGN_KEY_NO,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid signing key number."));
 
-    unsigned char p1 = (hashAlgo & 0x03) | ((nbKeyEntries & 0x03) << 2);
+    EXCEPTION_ASSERT_WITH_LOG(!requestAck || keyNoAck <= MAX_ACK_KEY_NO,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid acknowledgment key number."));
+
+    EXCEPTION_ASSERT_WITH_LOG(!encKeyFrame.empty(),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Encrypted key frame cannot be empty."));
+
+    EXCEPTION_ASSERT_WITH_LOG(!signature.empty(),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Signature cannot be empty."));
+
+    const unsigned char p1 = static_cast<unsigned char>((hashAlgo & 0x03) | ((nbKeyEntries & 0x03) << 2));
 
     ByteVector payload;
+    payload.reserve(2 + (requestAck ? 1 : 0) + encKeyFrame.size() + signature.size());
     payload.push_back(keyNoEnc);
     payload.push_back(keyNoSign);
     if (requestAck)
@@ -1606,42 +1692,29 @@ ByteVector SAMAV2ISO7816Commands::PKI_UpdateKeyEntries(
     payload.insert(payload.end(), encKeyFrame.begin(), encKeyFrame.end());
     payload.insert(payload.end(), signature.begin(), signature.end());
 
-    size_t offset = 0;
-    bool success  = false;
-    ByteVector result;
-
-    auto buildAPDU = [&](const ByteVector &data) -> ByteVector
-    {
-        ByteVector apdu;
-        apdu.push_back(d_cla);
-        apdu.push_back(sam::ins::pki::UpdateKeyEntries);
-        apdu.push_back(p1);
+    
+    const unsigned char lc =
+        payload.size() > sam::MAX_SECURE_APDU_DATA_SIZE ? 0x00 : static_cast<unsigned char>(payload.size());
+    ByteVector apdu;
+    apdu.reserve(payload.size() + (requestAck ? sam::APDU_HEADER_WITH_LE_SIZE : sam::APDU_HEADER_SIZE));
+    apdu.push_back(d_cla);
+    apdu.push_back(sam::ins::pki::UpdateKeyEntries);
+    apdu.push_back(p1);
+    apdu.push_back(0x00);
+    apdu.push_back(lc);
+    apdu.insert(apdu.end(), payload.begin(), payload.end());
+    if (requestAck)
         apdu.push_back(0x00);
-        if (data.size() > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC)
-            apdu.push_back(0x00);
-        else
-            apdu.push_back(static_cast<unsigned char>(data.size()));
-        apdu.insert(apdu.end(), data.begin(), data.end());
-        if (requestAck)
-            apdu.push_back(0x00);
-        return apdu;
-    };
 
-    const ByteVector fullPayload = buildAPDU(payload);
-    ByteVector resp = executeProtectedExchange(fullPayload, sam::ApduFormat::ExtendedWithLe);
-    if (resp.size() < sam::STATUS_WORD_SIZE)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_UpdateKeyEntries : response too short");
+    ByteVector response = executeProtectedExchange(apdu,
+        requestAck ? sam::ApduFormat::ExtendedWithLe : sam::ApduFormat::Extended);
+    validateSuccessResponse(response, __func__);
 
-    const uint16_t sw = sam::parseStatusWord(resp);
-    resp.resize(resp.size() - sam::STATUS_WORD_SIZE);
-    if (sw == 0x9000)
-        return resp;
-    if (sw == 0x6A80)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_UpdateKeyEntries : incorrect ChangeCtr");
-    THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                             "PKI_UpdateKeyEntries : unexpected status word");
+    if (!requestAck)
+        return {};
+
+    response.resize(response.size() - sam::STATUS_WORD_SIZE);
+    return response;
 }
 
 ByteVector SAMAV2ISO7816Commands::PKI_EncipherKeyEntries(
@@ -1680,7 +1753,7 @@ ByteVector SAMAV2ISO7816Commands::PKI_EncipherKeyEntries(
                              (divInput.empty() ? 0x00 : 0x10);
 
     ByteVector payload;
-    payload.reserve(6 + keyEntries.size() * 2 + divInput.size());
+    payload.reserve(6u + keyEntries.size() * 2u + divInput.size());
     payload.push_back(keyNoEnc);
     payload.push_back(keyNoSign);
     payload.push_back(keyNoDec);
@@ -1695,7 +1768,7 @@ ByteVector SAMAV2ISO7816Commands::PKI_EncipherKeyEntries(
         payload.insert(payload.end(), divInput.begin(), divInput.end());
 
     const unsigned char lc =
-        payload.size() > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC ? 0x00 : static_cast<unsigned char>(payload.size());
+        payload.size() > sam::MAX_SECURE_APDU_DATA_SIZE ? 0x00 : static_cast<unsigned char>(payload.size());
     ByteVector apdu{d_cla, sam::ins::pki::EncipherKeyEntries, p1, 0x00, lc};
     apdu.insert(apdu.end(), payload.begin(), payload.end());
     apdu.push_back(0x00);
@@ -1715,13 +1788,13 @@ ByteVector SAMAV2ISO7816Commands::PKI_GenerateHash(unsigned char hashAlgo, const
     EXCEPTION_ASSERT_WITH_LOG(!message.empty(),
         LibLogicalAccessException, sam::errorMessage(__func__, "Message cannot be empty."));
 
-    const uint32_t messageLen = static_cast<uint32_t>(message.size());
-    const size_t payloadSize  = sizeof(messageLen) + message.size();
+    const std::uint32_t messageLen = static_cast<std::uint32_t>(message.size());
+    const std::size_t payloadSize  = sizeof(messageLen) + message.size();
     const unsigned char lc =
-        payloadSize > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC ? 0x00 : static_cast<unsigned char>(payloadSize);
+        payloadSize > sam::MAX_SECURE_APDU_DATA_SIZE ? 0x00 : static_cast<unsigned char>(payloadSize);
 
     ByteVector apdu;
-    apdu.reserve(5 + payloadSize + 1);
+    apdu.reserve(sam::APDU_HEADER_WITH_LE_SIZE + payloadSize);
     apdu.push_back(d_cla);
     apdu.push_back(sam::ins::pki::GenerateHash);
     apdu.push_back(hashAlgo);
@@ -1749,15 +1822,15 @@ void SAMAV2ISO7816Commands::PKI_GenerateSignature(unsigned char hashAlgo, unsign
     EXCEPTION_ASSERT_WITH_LOG(keyNoSign <= 0x01,
         LibLogicalAccessException, sam::errorMessage(__func__, "Invalid key number."));
 
-    const size_t expectedSize = sam::expectedHashSize(hashAlgo);
+    const std::size_t expectedSize = sam::expectedHashSize(hashAlgo);
 
     EXCEPTION_ASSERT_WITH_LOG(hash.size() == expectedSize,
         LibLogicalAccessException, sam::errorMessage(__func__, "Invalid hash size for selected algorithm."));
 
-    const unsigned char lc = static_cast<unsigned char>(1 + hash.size());
+    const unsigned char lc = static_cast<unsigned char>(1u + hash.size());
 
     ByteVector apdu;
-    apdu.reserve(5 + lc);
+    apdu.reserve(sam::APDU_HEADER_SIZE + lc);
     apdu.push_back(d_cla);
     apdu.push_back(sam::ins::pki::GenerateSignature);
     apdu.push_back(hashAlgo);
@@ -1772,8 +1845,8 @@ void SAMAV2ISO7816Commands::PKI_GenerateSignature(unsigned char hashAlgo, unsign
 
 ByteVector SAMAV2ISO7816Commands::PKI_SendSignature()
 {
-    constexpr size_t MIN_SIG_SIZE = 8;
-    constexpr size_t MAX_SIG_SIZE = 256;
+    constexpr std::size_t MIN_SIG_SIZE = 8;
+    constexpr std::size_t MAX_SIG_SIZE = 256;
 
     ByteVector signature = transmit({d_cla, sam::ins::pki::SendSignature, 0x00, 0x00, 0x00}, true, true);
     validateSuccessResponse(signature, __func__);
@@ -1804,15 +1877,15 @@ void SAMAV2ISO7816Commands::PKI_VerifySignature(unsigned char hashAlgo,
         LibLogicalAccessException, sam::errorMessage(__func__, "Signature cannot be empty."));
 
     ByteVector payload;
-    payload.reserve(1 + hash.size() + signature.size());
+    payload.reserve(1u + hash.size() + signature.size());
     payload.push_back(keyNoVerif);
     payload.insert(payload.end(), hash.begin(), hash.end());
     payload.insert(payload.end(), signature.begin(), signature.end());
 
     const unsigned char lc =
-        payload.size() > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC ? 0x00 : static_cast<unsigned char>(payload.size());
+        payload.size() > sam::MAX_SECURE_APDU_DATA_SIZE ? 0x00 : static_cast<unsigned char>(payload.size());
     ByteVector apdu;
-    apdu.reserve(5 + payload.size());
+    apdu.reserve(sam::APDU_HEADER_SIZE + payload.size());
     apdu.push_back(d_cla);
     apdu.push_back(sam::ins::pki::VerifySignature);
     apdu.push_back(hashAlgo);
@@ -1838,12 +1911,12 @@ ByteVector SAMAV2ISO7816Commands::PKI_EncipherData(unsigned char hashAlgo,
                               sam::errorMessage(__func__, "Empty plaintext."));
 
     const unsigned char p1 = hashAlgo & 0x03;
-    const size_t payloadSize = 1 + plainData.size();
+    const std::size_t payloadSize = 1u + plainData.size();
     const unsigned char lc =
-        payloadSize > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC ? 0x00 : static_cast<unsigned char>(payloadSize);
+        payloadSize > sam::MAX_SECURE_APDU_DATA_SIZE ? 0x00 : static_cast<unsigned char>(payloadSize);
 
     ByteVector apdu;
-    apdu.reserve(5 + payloadSize + 1);
+    apdu.reserve(sam::APDU_HEADER_WITH_LE_SIZE + payloadSize);
     apdu.push_back(d_cla);
     apdu.push_back(sam::ins::pki::EncipherData);
     apdu.push_back(p1);
@@ -1878,12 +1951,12 @@ ByteVector SAMAV2ISO7816Commands::PKI_DecipherData(unsigned char hashAlgo,
         LibLogicalAccessException, sam::errorMessage(__func__, "Empty encrypted data."));
 
     const unsigned char p1 = hashAlgo & 0x03;
-    const size_t payloadSize = 1 + encData.size();
+    const std::size_t payloadSize = 1u + encData.size();
     const unsigned char lc =
-        payloadSize > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC ? 0x00 : static_cast<unsigned char>(payloadSize);
+        payloadSize > sam::MAX_SECURE_APDU_DATA_SIZE ? 0x00 : static_cast<unsigned char>(payloadSize);
 
     ByteVector apdu;
-    apdu.reserve(5 + payloadSize + 1);
+    apdu.reserve(sam::APDU_HEADER_WITH_LE_SIZE + payloadSize);
     apdu.push_back(d_cla);
     apdu.push_back(sam::ins::pki::DecipherData);
     apdu.push_back(p1);
@@ -1912,7 +1985,7 @@ void SAMAV2ISO7816Commands::PKI_ImportEccKey(
     EXCEPTION_ASSERT_WITH_LOG(keyNo <= 0x07,
         LibLogicalAccessException, sam::errorMessage(__func__, "Invalid keyNo (must be 0...7)."));
 
-    constexpr size_t PKI_IMPORT_ECC_MAX_PAYLOAD = 0x4B;
+    constexpr std::size_t PKI_IMPORT_ECC_MAX_PAYLOAD = 0x4B;
 
     const unsigned char p1 = settingsOnly ? 0x01 : 0x00;
 
@@ -1934,7 +2007,7 @@ void SAMAV2ISO7816Commands::PKI_ImportEccKey(
         EXCEPTION_ASSERT_WITH_LOG(eccPublicKey[0] == 0x04, LibLogicalAccessException,
             sam::errorMessage(__func__, "ECC public key must start with 0x04 (uncompressed format)."));
 
-        const size_t keySize = eccPublicKey.size();
+        const std::size_t keySize = eccPublicKey.size();
 
         EXCEPTION_ASSERT_WITH_LOG(keySize >= 33 && keySize <= 65, LibLogicalAccessException,
             sam::errorMessage(__func__, "Invalid ECC public key length (must be 33...65 bytes)."));
@@ -1954,7 +2027,7 @@ void SAMAV2ISO7816Commands::PKI_ImportEccKey(
     const unsigned char lc = static_cast<unsigned char>(payload.size());
 
     ByteVector apdu;
-    apdu.reserve(5 + payload.size());
+    apdu.reserve(sam::APDU_HEADER_SIZE + payload.size());
     apdu.push_back(d_cla);
     apdu.push_back(sam::ins::pki::ImportECCKey);
     apdu.push_back(p1);
@@ -1980,7 +2053,7 @@ void SAMAV2ISO7816Commands::PKI_ImportEccCurve(unsigned char curveNo, unsigned c
     const unsigned char p1 = settingsOnly ? 0x01 : 0x00;
 
     ByteVector payload;
-    payload.reserve(3 + eccCurve.size());
+    payload.reserve(3u + eccCurve.size());
     payload.push_back(curveNo);
     payload.push_back(keyNoCCK);
     payload.push_back(keyNoVCCK);
@@ -2002,14 +2075,16 @@ void SAMAV2ISO7816Commands::PKI_ImportEccCurve(unsigned char curveNo, unsigned c
         EXCEPTION_ASSERT_WITH_LOG(eccM >= 0x10 && eccM <= 0x20,
             LibLogicalAccessException, sam::errorMessage(__func__, "ECC_M out of range (0x10...0x20)."));
 
-        const size_t expectedSize = 2 + (5 * static_cast<size_t>(eccN)) + static_cast<size_t>(eccM);
+        constexpr std::size_t ECC_CURVE_HEADER_SIZE = 2u;
+        const std::size_t expectedSize = ECC_CURVE_HEADER_SIZE +
+            (5u * static_cast<std::size_t>(eccN)) + static_cast<std::size_t>(eccM);
 
         EXCEPTION_ASSERT_WITH_LOG(eccCurve.size() == expectedSize,
             LibLogicalAccessException, sam::errorMessage(__func__, "ECC curve length mismatch."));
 
-        size_t offset = 2;
+        std::size_t offset = ECC_CURVE_HEADER_SIZE;
 
-        const auto checkBlock = [&](size_t length, const char *name)
+        const auto checkBlock = [&](std::size_t length, const char *name)
         {
             EXCEPTION_ASSERT_WITH_LOG(offset + length <= eccCurve.size(),
                 LibLogicalAccessException, sam::errorMessage(__func__, std::string("Truncated field ") + name + "."));
@@ -2026,13 +2101,13 @@ void SAMAV2ISO7816Commands::PKI_ImportEccCurve(unsigned char curveNo, unsigned c
         payload.insert(payload.end(), eccCurve.begin(), eccCurve.end());
     }
 
-    EXCEPTION_ASSERT_WITH_LOG(payload.size() <= sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC,
+    EXCEPTION_ASSERT_WITH_LOG(payload.size() <= sam::MAX_SECURE_APDU_DATA_SIZE,
         LibLogicalAccessException, sam::errorMessage(__func__, "APDU payload too large."));
 
     const unsigned char lc = static_cast<unsigned char>(payload.size());
 
     ByteVector apdu;
-    apdu.reserve(5 + payload.size());
+    apdu.reserve(sam::APDU_HEADER_SIZE + payload.size());
     apdu.push_back(d_cla);
     apdu.push_back(sam::ins::pki::ImportECCCurve);
     apdu.push_back(p1);
@@ -2079,20 +2154,20 @@ void SAMAV2ISO7816Commands::PKI_VerifyEccSignature(unsigned char keyNo,
         LibLogicalAccessException, sam::errorMessage(__func__, "Signature cannot be empty."));
 
     ByteVector payload;
-    payload.reserve(3 + message.size() + signature.size());
+    payload.reserve(3u + message.size() + signature.size());
     payload.push_back(keyNo);
     payload.push_back(curveNo);
     payload.push_back(static_cast<unsigned char>(message.size()));
     payload.insert(payload.end(), message.begin(), message.end());
     payload.insert(payload.end(), signature.begin(), signature.end());
 
-    EXCEPTION_ASSERT_WITH_LOG(payload.size() <= sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC,
+    EXCEPTION_ASSERT_WITH_LOG(payload.size() <= sam::MAX_SECURE_APDU_DATA_SIZE,
         LibLogicalAccessException, sam::errorMessage(__func__, "APDU payload too large."));
 
     const unsigned char lc = static_cast<unsigned char>(payload.size());
 
     ByteVector apdu;
-    apdu.reserve(5 + payload.size());
+    apdu.reserve(sam::APDU_HEADER_SIZE + payload.size());
     apdu.push_back(d_cla);
     apdu.push_back(sam::ins::pki::VerifyECCSignature);
     apdu.push_back(0x00);

--- a/plugins/logicalaccess/plugins/readers/iso7816/commands/samav2iso7816commands.cpp
+++ b/plugins/logicalaccess/plugins/readers/iso7816/commands/samav2iso7816commands.cpp
@@ -74,10 +74,9 @@ void SAMAV2ISO7816Commands::generateSessionKey(ByteVector rnda, ByteVector rndb)
         SV2b[x + 9] ^= rndb[x];
 
     size_t sessionKeySize = d_macSessionKey.size();
-    if (sessionKeySize != AES_128_SIZE && sessionKeySize != AES_192_SIZE &&
-        sessionKeySize != AES_256_SIZE)
+    if (sessionKeySize != AES_128_SIZE && sessionKeySize != AES_192_SIZE && sessionKeySize != AES_256_SIZE)
         THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "generateSessionKey: Invalid session key size");
+            sam::errorMessage(__func__, "Invalid session key size."));
 
     static constexpr std::array<std::array<unsigned char, 4>, 3> SV_TAGS = {{
         {0x81, 0x00, 0x82, 0x00}, // AES 128
@@ -107,12 +106,12 @@ void SAMAV2ISO7816Commands::generateSessionKey(ByteVector rnda, ByteVector rndb)
 
     d_sessionKey    = Kea;
     d_macSessionKey = Kma;
-    if (sessionKeySize == 32) /* AES 256 */
+    if (sessionKeySize == AES_256_SIZE) /* AES 256 */
     {
         d_sessionKey.insert(d_sessionKey.end(), Keb.begin(), Keb.end());
         d_macSessionKey.insert(d_macSessionKey.end(), Kmb.begin(), Kmb.end());
     }
-    else if (sessionKeySize == 24) /* AES 192 */
+    else if (sessionKeySize == AES_192_SIZE) /* AES 192 */
     {
         for (unsigned char x = 0; x < 8; ++x)
         {
@@ -133,7 +132,7 @@ void SAMAV2ISO7816Commands::generateOfflineSessionKey(std::shared_ptr<DESFireKey
 {
     if (key->getKeyType() != DF_KEY_AES)
         THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "generateOfflineSessionKey Only AES Key allowed.");
+                                 sam::errorMessage(__func__, "Only AES Key allowed."));
 
     constexpr size_t BLOCK_SIZE   = 16;
     constexpr size_t AES_128_SIZE = 16;
@@ -144,7 +143,7 @@ void SAMAV2ISO7816Commands::generateOfflineSessionKey(std::shared_ptr<DESFireKey
 
     if (keysize != AES_128_SIZE && keysize != AES_192_SIZE && keysize != AES_256_SIZE)
         THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "generateOfflineSessionKey Invalid AES key size.");
+                                 sam::errorMessage(__func__, "Invalid AES key size."));
 
     d_sessionKey.clear();
     d_macSessionKey.clear();
@@ -202,8 +201,7 @@ void SAMAV2ISO7816Commands::generateOfflineSessionKey(std::shared_ptr<DESFireKey
     OPENSSL_cleanse(SV2b.data(), SV2b.size());
 }
 
-void SAMAV2ISO7816Commands::authenticateHost(std::shared_ptr<DESFireKey> key,
-                                             unsigned char keyno)
+void SAMAV2ISO7816Commands::authenticateHost(std::shared_ptr<DESFireKey> key, unsigned char keyno)
 {
     authenticateHost(key, keyno, sam::HostMode::FullProtect); // Host Mode: Full Protection
 }
@@ -211,85 +209,88 @@ void SAMAV2ISO7816Commands::authenticateHost(std::shared_ptr<DESFireKey> key,
 void SAMAV2ISO7816Commands::authenticateHost(std::shared_ptr<DESFireKey> key,
                                              unsigned char keyno, sam::HostMode hostmode)
 {
+    EXCEPTION_ASSERT_WITH_LOG(key != nullptr,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid key."));
 
-    if (key->getKeyType() != DF_KEY_AES)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "authenticateHost Only AES Key allowed.");
+    EXCEPTION_ASSERT_WITH_LOG(key->getKeyType() == DF_KEY_AES,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Only AES Key allowed."));
 
-    constexpr unsigned char AES_BLOCK_SIZE = 16;
-    constexpr unsigned char MAC_SIZE       = 8;
-    constexpr unsigned char RND_SIZE       = 12;
-    constexpr unsigned char RND_FULL_SIZE  = 16;
-    auto mode                              = sam::toByte(hostmode);
-    ByteVector emptyIV(AES_BLOCK_SIZE, 0x00);
-    ByteVector data_p1 = {keyno, key->getKeyVersion(), mode};
+    constexpr unsigned char RND_SIZE = 12;
+    const unsigned char mode         = sam::toByte(hostmode);
+    const ByteVector emptyIV(sam::AES_BLOCK_SIZE, 0x00);
     auto adapter       = getISO7816ReaderCardAdapter();
+    
+    const ByteVector keycipher = key->getData();
+    EXCEPTION_ASSERT_WITH_LOG(keycipher.size() == 16 || keycipher.size() == 24 || keycipher.size() == 32,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid AES key size."));
+
+    /* Reset host authentication state. */
+    d_hostMode = sam::HostMode::None;
 
     /* emptyIV and Clear Key */
+    secureZero(d_sessionKey);
+    secureZero(d_macSessionKey);
     d_lastMacIV     = emptyIV;
     d_LastSessionIV = emptyIV;
-    d_sessionKey.clear();
-    d_macSessionKey.clear();
 
-    auto result = adapter->sendAPDUCommand(d_cla, 0xa4, 0x00, 0x00, 0x03, data_p1, 0x00);
-    if (result.getData().size() != 12 || result.getSW1() != 0x90 ||
-        result.getSW2() != 0xAF)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "authenticateHost P1 Failed.");
+    const ByteVector data_p1 = {keyno, key->getKeyVersion(), mode};
+    auto result = adapter->sendAPDUCommand(d_cla, sam::ins::host::AuthenticateHost,
+        0x00, 0x00, static_cast<unsigned char>(data_p1.size()), data_p1, 0x00);
 
-    const ByteVector keycipher = key->getData();
-    d_macSessionKey            = keycipher;
-    auto cipher                = std::make_shared<openssl::AESCipher>();
+    EXCEPTION_ASSERT_WITH_LOG(result.getData().size() == 12 &&
+        result.getSW1() == sam::sw::SuccessSW1 && result.getSW2() == sam::sw::MoreDataSW2,
+        LibLogicalAccessException, sam::errorMessage(__func__, "P1 Failed."));
+
+    d_macSessionKey = keycipher;
+    auto cipher     = std::make_shared<openssl::AESCipher>();
 
     /* Create rnd2 for p3 - CMAC: rnd2 | Host Mode | ZeroPad */
     ByteVector rnd2 = result.getData();
     rnd2.push_back(mode);
-    rnd2.resize(AES_BLOCK_SIZE, 0x00); // ZeroPad
+    rnd2.resize(sam::AES_BLOCK_SIZE, 0x00); // ZeroPad
 
-    ByteVector macHost = openssl::CMACCrypto::cmac(d_macSessionKey, cipher, rnd2,
-                                                   d_lastMacIV, AES_BLOCK_SIZE);
+    ByteVector macHost = openssl::CMACCrypto::cmac(d_macSessionKey, cipher, rnd2, d_lastMacIV, sam::AES_BLOCK_SIZE);
     truncateMacBuffer(macHost);
 
     ByteVector rnd1(RND_SIZE);
-    if (RAND_bytes(&rnd1[0], static_cast<int>(rnd1.size())) != 1)
-    {
+    EXCEPTION_ASSERT_WITH_LOG(RAND_bytes(rnd1.data(), static_cast<int>(rnd1.size())) == 1,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Cannot retrieve cryptographically strong bytes."));
+    /*if (RAND_bytes(&rnd1[0], static_cast<int>(rnd1.size())) != 1)
         THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "Cannot retrieve cryptographically strong bytes");
-    }
+                                 sam::errorMessage(__func__, "Cannot retrieve cryptographically strong bytes"));*/
 
     ByteVector data_p2;
-    data_p2.insert(data_p2.end(), macHost.begin(), macHost.begin() + MAC_SIZE);
+    data_p2.reserve(sam::MAC_SIZE + rnd1.size());
+    data_p2.insert(data_p2.end(), macHost.begin(), macHost.begin() + sam::MAC_SIZE);
     data_p2.insert(data_p2.end(), rnd1.begin(), rnd1.end());
-    result = adapter->sendAPDUCommand(d_cla, 0xa4, 0x00, 0x00, 0x14, data_p2, 0x00);
-    if (result.getData().size() != 24 || result.getSW1() != 0x90 ||
-        result.getSW2() != 0xAF)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "authenticateHost P2 Failed.");
+    result = adapter->sendAPDUCommand(d_cla, sam::ins::host::AuthenticateHost,
+        0x00, 0x00, static_cast<unsigned char>(data_p2.size()), data_p2, 0x00);
+    EXCEPTION_ASSERT_WITH_LOG(result.getData().size() == 24 &&
+        result.getSW1() == sam::sw::SuccessSW1 && result.getSW2() == sam::sw::MoreDataSW2,
+        LibLogicalAccessException, sam::errorMessage(__func__, "P2 Failed."));
 
     /* Check CMAC - Create rnd1 for p3 - CMAC: rnd1 | P1 | other data */
     rnd1.insert(rnd1.end(), rnd2.begin() + RND_SIZE, rnd2.end()); // p2 data without rnd2
-    macHost = openssl::CMACCrypto::cmac(d_macSessionKey, cipher, rnd1, d_lastMacIV,
-                                        AES_BLOCK_SIZE);
+    macHost = openssl::CMACCrypto::cmac(d_macSessionKey, cipher, rnd1, d_lastMacIV, sam::AES_BLOCK_SIZE);
     truncateMacBuffer(macHost);
-    for (unsigned char x = 0; x < MAC_SIZE; ++x)
-    {
-        if (macHost[x] != result.getData()[x])
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "authenticateHost P2 CMAC from SAM is Wrong.");
-    }
+    EXCEPTION_ASSERT_WITH_LOG(std::equal(macHost.begin(), macHost.begin() + sam::MAC_SIZE, result.getData().begin()),
+        LibLogicalAccessException, sam::errorMessage(__func__, "P2 CMAC from SAM is wrong."));
 
     /* Create kxe - d_authKey */
     generateAuthEncKey(keycipher, rnd1, rnd2);
     // create rndA
-    ByteVector rndA(AES_BLOCK_SIZE);
-    if (RAND_bytes(&rndA[0], static_cast<int>(rndA.size())) != 1)
+    ByteVector rndA(sam::AES_BLOCK_SIZE);
+    EXCEPTION_ASSERT_WITH_LOG(RAND_bytes(rndA.data(), static_cast<int>(rndA.size())) == 1,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Cannot retrieve cryptographically strong bytes."));
+    /*if (RAND_bytes(&rndA[0], static_cast<int>(rndA.size())) != 1)
         THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "Cannot retrieve cryptographically strong bytes");
+                                 sam::errorMessage(__func__, "Cannot retrieve cryptographically strong bytes"));*/
+
     // decipher rndB
     auto symkey = openssl::AESSymmetricKey::createFromData(d_authKey);
     auto iv     = openssl::AESInitializationVector::createFromData(d_lastMacIV);
 
-    ByteVector encRndB(result.getData().begin() + MAC_SIZE, result.getData().end());
+    ByteVector encRndB(result.getData().begin() + sam::MAC_SIZE, result.getData().end());
     ByteVector dencRndB;
     cipher->decipher(encRndB, dencRndB, symkey, iv, false);
 
@@ -300,6 +301,7 @@ void SAMAV2ISO7816Commands::authenticateHost(std::shared_ptr<DESFireKey> key,
     rndB1.push_back(dencRndB[1]);
 
     ByteVector dataHost;
+    dataHost.reserve(rndA.size() + rndB1.size());
     dataHost.insert(dataHost.end(), rndA.begin(), rndA.end());   // RndA
     dataHost.insert(dataHost.end(), rndB1.begin(), rndB1.end()); // RndB'
 
@@ -307,80 +309,74 @@ void SAMAV2ISO7816Commands::authenticateHost(std::shared_ptr<DESFireKey> key,
     ByteVector encHost;
 
     cipher->cipher(dataHost, encHost, symkey, iv, false);
-    result = adapter->sendAPDUCommand(d_cla, 0xa4, 0x00, 0x00, 0x20, encHost, 0x00);
-    if (result.getData().size() != AES_BLOCK_SIZE || result.getSW1() != 0x90 ||
-        result.getSW2() != 0x00)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "authenticateHost P3 Failed.");
+    result = adapter->sendAPDUCommand(d_cla, sam::ins::host::AuthenticateHost,
+        0x00, 0x00, static_cast<unsigned char>(encHost.size()), encHost, 0x00);
+    EXCEPTION_ASSERT_WITH_LOG(result.getData().size() == sam::AES_BLOCK_SIZE &&
+        result.getSW1() == sam::sw::SuccessSW1 && result.getSW2() == sam::sw::SuccessSW2,
+        LibLogicalAccessException, sam::errorMessage(__func__, "P3 Failed."));
 
     ByteVector SAMrndA;
     iv = openssl::AESInitializationVector::createFromData(d_lastMacIV);
     cipher->decipher(result.getData(), SAMrndA, symkey, iv, false);
     SAMrndA.insert(SAMrndA.begin(), SAMrndA.end() - 2, SAMrndA.end());
 
-    if (!equal(SAMrndA.begin(), SAMrndA.begin() + AES_BLOCK_SIZE, rndA.begin()))
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "authenticateHost P3 RndA from SAM is invalid.");
+    EXCEPTION_ASSERT_WITH_LOG(std::equal(SAMrndA.begin(), SAMrndA.begin() + sam::AES_BLOCK_SIZE, rndA.begin()),
+        LibLogicalAccessException, sam::errorMessage(__func__, "P3 RndA from SAM is invalid."));
+
     generateSessionKey(rndA, dencRndB);
     d_cmdCtr = 0;
+    d_hostMode = hostmode;
 
-    OPENSSL_cleanse(rnd1.data(), rnd1.size());
-    OPENSSL_cleanse(rnd2.data(), rnd2.size());
-    OPENSSL_cleanse(rndA.data(), rndA.size());
-    OPENSSL_cleanse(dencRndB.data(), dencRndB.size());
-    OPENSSL_cleanse(rndB1.data(), rndB1.size());
-    OPENSSL_cleanse(dataHost.data(), dataHost.size());
-    OPENSSL_cleanse(encRndB.data(), encRndB.size());
-    OPENSSL_cleanse(SAMrndA.data(), SAMrndA.size());
-    OPENSSL_cleanse(macHost.data(), macHost.size());
+    secureZero(rnd1);
+    secureZero(rnd2);
+    secureZero(rndA);
+    secureZero(dencRndB);
+    secureZero(rndB1);
+    secureZero(dataHost);
+    secureZero(encHost);
+    secureZero(encRndB);
+    secureZero(SAMrndA);
+    secureZero(macHost);
 }
 
-sam::ApduResult SAMAV2ISO7816Commands::createfullProtectionCmd(const ByteVector &cmd, sam::ApduFormat format)
+sam::ProtectedApdu SAMAV2ISO7816Commands::prepareProtectedApdu(const ByteVector &cmd, sam::ApduFormat format)
 {
     if (cmd.size() < AV2_HEADER_LENGTH)
         THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "createfullProtectionCmd Invalid command size.");
+                                 sam::errorMessage(__func__, "Invalid command size."));
 
-    constexpr size_t AES_BLOCK_SIZE         = 16;
-    constexpr unsigned char ISO7816_PADDING = 0x80;
     ByteVector protectedCmd, encData;
 
-    bool lc = false, le = false;
-    if (format == sam::ApduFormat::Standard)
-        getLcLe(cmd, lc, le);
-    else
-    {
-        lc = true;
-        le = (format == sam::ApduFormat::ExtendedWithLe);
-    }
+    const auto apduInfo = getApduInfo(cmd, format);
+    const bool encrypt = (d_hostMode == sam::HostMode::FullProtect);
 
-    auto cipher = std::make_shared<openssl::AESCipher>();
-
-    if (!lc)
+    if (!apduInfo.hasLc)
     {
         protectedCmd = cmd;
-        protectedCmd.insert(protectedCmd.begin() + AV2_LC_POS, 0x08);
+        protectedCmd.insert(protectedCmd.begin() + AV2_LC_POS, sam::MAC_SIZE);
     }
     else
     {
-        const size_t dataEnd = cmd.size() - (le ? 1u : 0u);
-        protectedCmd.insert(protectedCmd.end(), cmd.begin(), cmd.begin() + AV2_HEADER_LENGTH);
-        if (le)
-            protectedCmd.push_back(cmd.back());
+        const size_t dataEnd = cmd.size() - (apduInfo.hasLe ? 1u : 0u);
         ByteVector data(cmd.begin() + AV2_HEADER_LENGTH, cmd.begin() + dataEnd);
-        if (data.size() % AES_BLOCK_SIZE != 0)
+        if (encrypt)
         {
-            data.push_back(ISO7816_PADDING);
-            data.resize(((data.size() + AES_BLOCK_SIZE - 1) / AES_BLOCK_SIZE) * AES_BLOCK_SIZE, 0x00);
+            encData = encryptCommandData(data);
+            protectedCmd.insert(protectedCmd.end(), cmd.begin(), cmd.begin() + AV2_HEADER_LENGTH);
+            if (apduInfo.hasLe)
+                protectedCmd.push_back(cmd.back());
+            protectedCmd.insert(protectedCmd.begin() + AV2_HEADER_LENGTH, encData.begin(), encData.end());
+            protectedCmd[AV2_LC_POS] =
+                (encData.size() > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC) ? 0x00 : static_cast<unsigned char>(encData.size() + sam::MAC_SIZE);
         }
-        /* generate IV because first encrypt */
-        d_LastSessionIV = generateEncIV(true);
-        const auto symkeySession = openssl::AESSymmetricKey::createFromData(d_sessionKey);
-        const auto ivSession = openssl::AESInitializationVector::createFromData(d_LastSessionIV);
-        cipher->cipher(data, encData, symkeySession, ivSession, false);
-        protectedCmd.insert(protectedCmd.begin() + AV2_HEADER_LENGTH, encData.begin(), encData.end());
-        protectedCmd[AV2_LC_POS] =
-            (encData.size() > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC) ? 0x00 : static_cast<unsigned char>(encData.size() + 8);
+        else
+        {
+            encData = data;
+            protectedCmd = cmd;
+            const size_t dataLen = data.size();
+            protectedCmd[AV2_LC_POS] =
+                (dataLen > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC) ? 0x00 : static_cast<unsigned char>(dataLen + sam::MAC_SIZE);
+        }
     }
 
     /* Set counter */
@@ -390,218 +386,172 @@ sam::ApduResult SAMAV2ISO7816Commands::createfullProtectionCmd(const ByteVector 
     std::reverse(cmdCtr.begin(), cmdCtr.end());
     protectedCmd.insert(protectedCmd.begin() + 2, cmdCtr.begin(), cmdCtr.end());
 
-    const size_t blockReady = (protectedCmd.size() / AES_BLOCK_SIZE) * AES_BLOCK_SIZE;
-    if (blockReady >= AES_BLOCK_SIZE)
+    ByteVector macFull = computeCommandMac(protectedCmd);
+
+    return {encData, macFull, apduInfo.hasLe};
+}
+
+ByteVector SAMAV2ISO7816Commands::computeCommandMac(ByteVector &protectedCmd)
+{
+    const auto cipher = std::make_shared<openssl::AESCipher>();
+    const size_t blockReady = (protectedCmd.size() / sam::AES_BLOCK_SIZE) * sam::AES_BLOCK_SIZE;
+    if (blockReady >= sam::AES_BLOCK_SIZE)
     {
-        /* Creater our cipher buffer and keep last block */
+        /* Encrypt complete blocks and preserve last MAC IV. */
         const auto symkeyMac = openssl::AESSymmetricKey::createFromData(d_macSessionKey);
         const auto ivMac = openssl::AESInitializationVector::createFromData(d_lastMacIV);
         ByteVector macInput(protectedCmd.begin(), protectedCmd.begin() + blockReady);
         ByteVector macCiphertext(macInput.size());
         protectedCmd.erase(protectedCmd.begin(), protectedCmd.begin() + blockReady);
         cipher->cipher(macInput, macCiphertext, symkeyMac, ivMac, false);
-        EXCEPTION_ASSERT_WITH_LOG(macCiphertext.size() >= AES_BLOCK_SIZE, LibLogicalAccessException, "Cipher output error.");
-        d_lastMacIV.assign(macCiphertext.end() - AES_BLOCK_SIZE, macCiphertext.end());
+        EXCEPTION_ASSERT_WITH_LOG(macCiphertext.size() >= sam::AES_BLOCK_SIZE, LibLogicalAccessException,
+            sam::errorMessage(__func__, "Cipher output error."));
+        d_lastMacIV.assign(macCiphertext.end() - sam::AES_BLOCK_SIZE, macCiphertext.end());
     }
-    ByteVector macFull = openssl::CMACCrypto::cmac(d_macSessionKey, cipher, protectedCmd, d_lastMacIV, AES_BLOCK_SIZE);
-    truncateMacBuffer(macFull);
-    return {encData, macFull, le};
+    ByteVector mac = openssl::CMACCrypto::cmac(d_macSessionKey, cipher, protectedCmd, d_lastMacIV, sam::AES_BLOCK_SIZE);
+    truncateMacBuffer(mac);
+    return mac;
+}
+
+ByteVector SAMAV2ISO7816Commands::encryptCommandData(const ByteVector &data)
+{
+    constexpr unsigned char ISO7816_PADDING = 0x80;
+
+    ByteVector paddedData = data;
+    if (paddedData.size() % sam::AES_BLOCK_SIZE != 0)
+    {
+        paddedData.push_back(ISO7816_PADDING);
+        paddedData.resize(((paddedData.size() + sam::AES_BLOCK_SIZE - 1) / sam::AES_BLOCK_SIZE) * sam::AES_BLOCK_SIZE, 0x00);
+    }
+    openssl::AESCipher cipher;
+    /* Generate session IV for command encryption */
+    d_LastSessionIV = generateEncIV(true);
+    const auto symkeySession = openssl::AESSymmetricKey::createFromData(d_sessionKey);
+    const auto ivSession = openssl::AESInitializationVector::createFromData(d_LastSessionIV);
+    ByteVector encrypted;
+    cipher.cipher(paddedData, encrypted, symkeySession, ivSession, false);
+    return encrypted;
 }
 
 void SAMAV2ISO7816Commands::getLcLe(const ByteVector &cmd, bool &lc, bool &le)
 {
     const size_t cmdSize = cmd.size();
 
-    if (cmdSize < AV2_HEADER_LENGTH)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "getLcLe cmd param is too small.");
+    EXCEPTION_ASSERT_WITH_LOG(cmdSize >= AV2_HEADER_LENGTH, LibLogicalAccessException,
+        sam::errorMessage(__func__, "APDU is shorter than the command header."));
 
     lc = false;
     le = false;
 
-    // [CLA INS P1 P2]
+    // Command header only : [CLA INS P1 P2]
     if (cmdSize == AV2_LC_POS)
         return;
-    // [CLA INS P1 P2 LE]
+    // Header only with Le : [CLA INS P1 P2 LE]
     if (cmdSize == AV2_HEADER_LENGTH)
     {
         le = true;
         return;
     }
     const unsigned char lcByte = cmd[AV2_LC_POS];
-    // [CLA INS P1 P2 LC DATA]
-    if (cmdSize == static_cast<size_t>(lcByte) + AV2_HEADER_LENGTH)
+    const size_t expectedSizeWithLc = static_cast<size_t>(lcByte) + AV2_HEADER_LENGTH;
+    const size_t expectedSizeWithLcLe = static_cast<size_t>(lcByte) + AV2_HEADER_LENGTH_WITH_LE;
+    // Header, Lc and data : [CLA INS P1 P2 LC DATA]
+    if (cmdSize == expectedSizeWithLc)
     {
         lc = true;
         return;
     }
-    // [CLA INS P1 P2 LC DATA LE]
-    if (cmdSize == static_cast<size_t>(lcByte) + AV2_HEADER_LENGTH_WITH_LE)
+    // Header, Lc, data and Le : [CLA INS P1 P2 LC DATA LE]
+    if (cmdSize == expectedSizeWithLcLe)
     {
         lc = true;
         le = true;
         return;
     }
-    THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "getLcLe invalid command structure (size mismatch).");
+    THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, sam::errorMessage(__func__, "Invalid APDU structure."));
+}
+
+sam::ApduInfo SAMAV2ISO7816Commands::getApduInfo(const ByteVector &cmd, sam::ApduFormat format)
+{
+    sam::ApduInfo info;
+    if (format == sam::ApduFormat::Standard || format == sam::ApduFormat::ExtendedResponseOnly)
+        getLcLe(cmd, info.hasLc, info.hasLe);
+    else
+    {
+        info.hasLc = true;
+        info.hasLe = (format == sam::ApduFormat::ExtendedWithLe);
+    }
+    return info;
 }
 
 ByteVector SAMAV2ISO7816Commands::verifyAndDecryptResponse(const ByteVector &response)
 {
-    constexpr size_t MAC_SIZE    = 8;
-    constexpr size_t STATUS_SIZE = 2;
+    if (d_hostMode != sam::HostMode::MAC && d_hostMode != sam::HostMode::FullProtect)
+        THROW_EXCEPTION_WITH_LOG( LibLogicalAccessException,
+            sam::errorMessage(__func__, "Requires MAC or FullProtect host mode."));
 
     /* begin check mac */
-    if (response.size() < MAC_SIZE + STATUS_SIZE)
+    if (response.size() < sam::MAC_SIZE + sam::STATUS_WORD_SIZE)
         return response;
 
-    auto cipher = std::make_shared<openssl::AESCipher>();
+    const auto cipher = std::make_shared<openssl::AESCipher>();
+    ByteVector mac(response.end() - sam::MAC_SIZE - sam::STATUS_WORD_SIZE, response.end() - sam::STATUS_WORD_SIZE);
 
-    ByteVector myMac, cmdCtrVector, myEncMac, data;
-    ByteVector mac(response.end() - MAC_SIZE - STATUS_SIZE, response.end() - STATUS_SIZE);
-
-    myMac.push_back(response[response.size() - 2]);
-    myMac.push_back(response[response.size() - 1]);
+    ByteVector macInput, cmdCtrVector, macCiphertext;
+    macInput.push_back(response[response.size() - 2]);
+    macInput.push_back(response[response.size() - 1]);
 
     /* Set counter */
     BufferHelper::setUInt32(cmdCtrVector, d_cmdCtr);
     std::reverse(cmdCtrVector.begin(), cmdCtrVector.end());
-    myMac.insert(myMac.end(), cmdCtrVector.begin(), cmdCtrVector.end());
+    macInput.insert(macInput.end(), cmdCtrVector.begin(), cmdCtrVector.end());
 
-    if (response.size() != MAC_SIZE + STATUS_SIZE)
+    const bool hasPayload = response.size() > sam::MAC_SIZE + sam::STATUS_WORD_SIZE;
+    if (hasPayload)
     {
-        /* We have data Creater our cipher buffer and keep last block */
+        /* Encrypt complete MAC blocks and preserve chaining IV. */
         auto symkeyMac = openssl::AESSymmetricKey::createFromData(d_macSessionKey);
         auto ivMac     = openssl::AESInitializationVector::createFromData(d_lastMacIV);
-        myMac.insert(myMac.end(), response.begin(), response.end() - MAC_SIZE - STATUS_SIZE);
-        const size_t blockReady = (myMac.size() / 16) * 16;
-        ByteVector lastBlock(myMac.begin() + blockReady, myMac.end());
-        myMac.erase(myMac.begin() + blockReady, myMac.end());
-        cipher->cipher(myMac, myEncMac, symkeyMac, ivMac, false);
-        d_lastMacIV.assign(myEncMac.end() - 16, myEncMac.end());
-        myMac = lastBlock;
+        macInput.insert(macInput.end(), response.begin(), response.end() - sam::MAC_SIZE - sam::STATUS_WORD_SIZE);
+        const size_t blockReady = (macInput.size() / sam::AES_BLOCK_SIZE) * sam::AES_BLOCK_SIZE;
+        ByteVector lastBlock(macInput.begin() + blockReady, macInput.end());
+        macInput.erase(macInput.begin() + blockReady, macInput.end());
+        cipher->cipher(macInput, macCiphertext, symkeyMac, ivMac, false);
+        d_lastMacIV.assign(macCiphertext.end() - sam::AES_BLOCK_SIZE, macCiphertext.end());
+        macInput = std::move(lastBlock);
     }
-
-    myEncMac = openssl::CMACCrypto::cmac(d_macSessionKey, cipher, myMac, d_lastMacIV, 16);
-    truncateMacBuffer(myEncMac);
-
-    if (!equal(myEncMac.begin(), myEncMac.begin() + MAC_SIZE, mac.begin()))
-        THROW_EXCEPTION_WITH_LOG(
-            LibLogicalAccessException,
-            "verifyAndDecryptResponse wasnt able to verify the answer of the sam");
-
-    if (response.size() > MAC_SIZE + STATUS_SIZE)
-    {
-        /* begin decrypt */
-        /* generate IV because first decrypt */
-        auto symkeySession = openssl::AESSymmetricKey::createFromData(d_sessionKey);
-        d_LastSessionIV    = generateEncIV(false);
-        auto ivSession =
-            openssl::AESInitializationVector::createFromData(d_LastSessionIV);
-        ByteVector encData(response.begin(), response.end() - MAC_SIZE - STATUS_SIZE);
-        cipher->decipher(encData, data, symkeySession, ivSession, false);
-
-        int i = static_cast<int>(data.size()) - 1;
-        while (i >= 0 && data[i] != 0x80 && data[i] == 0x00)
-            --i;
-        if (i >= 0)
-            data.resize(i);
-    }
-    data.push_back(response[response.size() - 2]);
-    data.push_back(response[response.size() - 1]);
-    return data;
-}
-
-// TODO update this function
-ByteVector SAMAV2ISO7816Commands::createMacProtectionCmd(const ByteVector &cmd)
-{
-    if (cmd.size() < AV2_HEADER_LENGTH)
+    macCiphertext = openssl::CMACCrypto::cmac(d_macSessionKey, cipher, macInput, d_lastMacIV, sam::AES_BLOCK_SIZE);
+    truncateMacBuffer(macCiphertext);
+    if (!std::equal(macCiphertext.begin(), macCiphertext.begin() + sam::MAC_SIZE, mac.begin()))
         THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "createMacProtectionCmd Invalid command size.");
-    constexpr unsigned char MAC_SIZE = 8;
-    bool lc = false, le = false;
-    bool lcvalue = 0; //TODO placeholder
-    getLcLe(cmd, lc, le);
-    auto cipher = std::make_shared<openssl::AESCipher>();
-    ByteVector protectedCmd = cmd;
+            sam::errorMessage(__func__, "Response CMAC verification failed."));
 
-    if (!lc)
-        protectedCmd.insert(protectedCmd.begin() + AV2_LC_POS, MAC_SIZE);
-    else
-        protectedCmd[AV2_LC_POS] = static_cast<unsigned char>(lcvalue + MAC_SIZE);
-    ByteVector finalCmd = protectedCmd;
-
-    /* Set counter */
-    ByteVector cmdCtrVector;
-    BufferHelper::setUInt32(cmdCtrVector, d_cmdCtr);
-    std::reverse(cmdCtrVector.begin(), cmdCtrVector.end());
-
-    protectedCmd.insert(protectedCmd.begin() + 2, cmdCtrVector.begin(),
-                        cmdCtrVector.end());
-
-    /* Create our cipher buffer and keep last block */
-    auto symkeyMac = openssl::AESSymmetricKey::createFromData(d_macSessionKey);
-    auto ivMac     = openssl::AESInitializationVector::createFromData(d_lastMacIV);
-
-    const size_t blockReady = (protectedCmd.size() / 16) * 16;
-    if (blockReady >= 16)
+    ByteVector data;
+    if (hasPayload)
     {
-        ByteVector encMac(protectedCmd.begin(), protectedCmd.begin() + blockReady);
-        ByteVector tmp(encMac.size());
-        protectedCmd.erase(protectedCmd.begin(), protectedCmd.begin() + blockReady);
-        cipher->cipher(encMac, tmp, symkeyMac, ivMac, false);
-        EXCEPTION_ASSERT_WITH_LOG(tmp.size() >= 16, LibLogicalAccessException, "Cipher output too small.");
-        d_lastMacIV.assign(tmp.end() - 16, tmp.end());
+        if (d_hostMode == sam::HostMode::FullProtect)
+        {
+            /* begin decrypt */
+            /* generate IV because first decrypt */
+            auto symkeySession = openssl::AESSymmetricKey::createFromData(d_sessionKey);
+            d_LastSessionIV = generateEncIV(false);
+            auto ivSession = openssl::AESInitializationVector::createFromData(d_LastSessionIV);
+            ByteVector encData(response.begin(), response.end() - sam::MAC_SIZE - sam::STATUS_WORD_SIZE);
+            cipher->decipher(encData, data, symkeySession, ivSession, false);
+            int i = static_cast<int>(data.size()) - 1;
+            while (i >= 0 && data[i] != 0x80 && data[i] == 0x00)
+                --i;
+            if (i >= 0)
+                data.resize(i);
+        }
+        else
+        {
+            data.assign(response.begin(), response.end() - sam::MAC_SIZE - sam::STATUS_WORD_SIZE);
+        }
     }
-
-    ByteVector encProtectedCmd = openssl::CMACCrypto::cmac(d_macSessionKey, cipher, protectedCmd, d_lastMacIV, 16);
-    truncateMacBuffer(encProtectedCmd);
-    const size_t dataSize = lc ? lcvalue : 0;
-    finalCmd.insert(finalCmd.begin() + AV2_HEADER_LENGTH + dataSize,
-                    encProtectedCmd.begin(), encProtectedCmd.begin() + MAC_SIZE);
-    return finalCmd;
-}
-
-ByteVector SAMAV2ISO7816Commands::verifyAndDecryptMacResponse(const ByteVector &response)
-{
-    constexpr size_t MAC_SIZE    = 8;
-    constexpr size_t STATUS_SIZE = 2;
-
-    if (response.size() < MAC_SIZE + STATUS_SIZE)
-        return response;
-
-    auto cipher = std::make_shared<openssl::AESCipher>();
-
-    ByteVector mac(response.end() - MAC_SIZE - STATUS_SIZE, response.end() - STATUS_SIZE);
-    ByteVector myMac, cmdCtrVector, myEncMac;
-
-    myMac.push_back(response[response.size() - 2]);
-    myMac.push_back(response[response.size() - 1]);
-
-    BufferHelper::setUInt32(cmdCtrVector, d_cmdCtr);
-    std::reverse(cmdCtrVector.begin(), cmdCtrVector.end());
-    myMac.insert(myMac.end(), cmdCtrVector.begin(), cmdCtrVector.end());
-
-    if (response.size() > MAC_SIZE + STATUS_SIZE)
-    {
-        myMac.insert(myMac.end(), response.begin(),
-                     response.end() - MAC_SIZE - STATUS_SIZE);
-        const size_t blockReady = (myMac.size() / 16) * 16;
-        ByteVector lastBlock(myMac.begin() + blockReady, myMac.end());
-        myMac.erase(myMac.begin() + blockReady, myMac.end());
-        auto symkeyMac = openssl::AESSymmetricKey::createFromData(d_macSessionKey);
-        auto ivMac     = openssl::AESInitializationVector::createFromData(d_lastMacIV);
-        cipher->cipher(myMac, myEncMac, symkeyMac, ivMac, false);
-        d_lastMacIV.assign(myEncMac.end() - 16, myEncMac.end());
-        myMac = lastBlock;
-    }
-    myEncMac = openssl::CMACCrypto::cmac(d_macSessionKey, cipher, myMac, d_lastMacIV, 16);
-    truncateMacBuffer(myEncMac);
-    if (!equal(myEncMac.begin(), myEncMac.begin() + MAC_SIZE, mac.begin()))
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "verifyAndDecryptMacResponse: MAC verification failed");
-    ByteVector data(response.begin(), response.end() - MAC_SIZE - STATUS_SIZE);
-    data.push_back(response[response.size() - 2]);
-    data.push_back(response[response.size() - 1]);
+    const auto swOffset = response.size() - sam::STATUS_WORD_SIZE;
+    data.push_back(response[swOffset]);
+    data.push_back(response[swOffset + 1]);
     return data;
 }
 
@@ -636,290 +586,21 @@ ByteVector SAMAV2ISO7816Commands::generateEncIV(bool encrypt) const
     return encIV;
 }
 
-//TODO merge (for single transmit func)
-ByteVector SAMAV2ISO7816Commands::transmitSecureChained(const ByteVector &cmd, sam::ApduFormat format, const sam::ChainingLayout &layout)
-{
-    if (cmd.size() < AV2_HEADER_LENGTH)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "Invalid APDU : too short");
-
-    try
-    {
-        auto protection = createfullProtectionCmd(cmd, format);
-        auto frames = createChainedApduFrames(cmd, protection.encData, protection.mac, layout, protection.hasLe);
-        ByteVector response = sendChainedFrames(frames, cmd[1]);
-        return finalizeSecureResponse(std::move(response));
-    }
-    catch (const std::exception &e)
-    {
-        secureZero(d_sessionKey);
-        secureZero(d_macSessionKey);
-        resetIVs();
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, std::string("SAM transmit failed : ") + e.what());
-    }
-}
-
-std::vector<ByteVector> SAMAV2ISO7816Commands::createChainedApduFrames(const ByteVector &cmd, const ByteVector &encData,
-    const ByteVector &mac, const sam::ChainingLayout &layout, bool le)
-{
-    if (cmd.size() < AV2_HEADER_LENGTH)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "Invalid APDU : too short");
-
-    constexpr size_t MAX_CHUNK_SIZE = sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC;
-    constexpr size_t MAC_SIZE       = 8;
-    constexpr unsigned char PX_MORE = 0xAF;
-    constexpr unsigned char PX_LAST = 0x00;
-
-    const unsigned char cla = cmd[0];
-    const unsigned char ins = cmd[1];
-    const unsigned char p1  = cmd[2];
-    const unsigned char p2  = cmd[3];
-
-    if (mac.size() < MAC_SIZE)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "MAC too short for final frame");
-
-    std::vector<ByteVector> frames;
-    const size_t frameCount = (encData.size() + MAX_CHUNK_SIZE - 1) / MAX_CHUNK_SIZE;
-    frames.reserve(frameCount);
-    auto buildFrame = [&](size_t offset, size_t chunkSize, bool isLastChunk) -> ByteVector
-    {
-        ByteVector frame;
-        frame.reserve(AV2_HEADER_LENGTH + chunkSize + (isLastChunk ? MAC_SIZE : 0));
-        frame.push_back(cla);
-        frame.push_back(ins);
-        frame.push_back(p1);
-        frame.push_back(p2);
-        frame.push_back(0x00);
-        auto it = encData.begin() + offset;
-        frame.insert(frame.end(), it, it + chunkSize);
-        if (isLastChunk)
-            frame.insert(frame.end(), mac.begin(), mac.begin() + MAC_SIZE);
-        frame[layout.lastFrameIndex] = static_cast<unsigned char>(isLastChunk ? PX_LAST : PX_MORE);
-        if (offset > 0)
-            frame[layout.modeIndex] = 0x00;
-        const size_t lc = frame.size() - AV2_HEADER_LENGTH;
-        if (lc > sam::MAX_APDU_DATA_SIZE)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "LC overflow in APDU frame");
-        frame[AV2_LC_POS] = static_cast<unsigned char>(lc);
-        return frame;
-    };
-
-    size_t offset = 0;
-    while (offset < encData.size())
-    {
-        const size_t remaining = encData.size() - offset;
-        const size_t chunkSize = (std::min)(MAX_CHUNK_SIZE, remaining);
-        const bool isFirstChunk = (offset == 0);
-        const bool isLastChunk = (offset + chunkSize >= encData.size());
-        frames.emplace_back(buildFrame(offset, chunkSize, isLastChunk));
-        offset += chunkSize;
-    }
-
-    if (le && !frames.empty())
-        frames.back().push_back(cmd.back());
-
-    return frames;
-}
-
-ByteVector SAMAV2ISO7816Commands::sendChainedFrames(const std::vector<ByteVector> &frames, unsigned char ins)
-{
-    constexpr unsigned char SW1_SUCCESS = 0x90;
-    constexpr unsigned char SW2_MORE    = 0xAF;
-
-    auto adapter = getISO7816ReaderCardAdapter();
-
-    ByteVector response;
-
-    unsigned char sw1 = 0;
-    unsigned char sw2 = 0;
-    for (size_t i = 0; i < frames.size(); ++i)
-    {
-        auto r = adapter->sendCommand(frames[i]);
-        if (r.size() < 2)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "Invalid response");
-        sw1 = r[r.size() - 2];
-        sw2 = r[r.size() - 1];
-        const bool lastFrame = (i + 1 == frames.size());
-        response.insert(response.end(), r.begin(), r.end() - 2);
-        if (!lastFrame && !(sw1 == SW1_SUCCESS && sw2 == SW2_MORE))
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "Expected 90AF for intermediate frame");
-    }
-    return receiveChainedResponse(ins, std::move(response), sw1, sw2);
-}
-
-ByteVector SAMAV2ISO7816Commands::receiveChainedResponse(unsigned char ins, ByteVector response, unsigned char sw1, unsigned char sw2)
-{
-    constexpr unsigned char SW1_SUCCESS = 0x90;
-    constexpr unsigned char SW2_MORE    = 0xAF;
-    constexpr unsigned char SW2_OK      = 0x00;
-
-    auto adapter = getISO7816ReaderCardAdapter();
-
-    const ByteVector continueApdu = {d_cla, ins, 0x00, 0x00, 0x00};
-
-    while (sw1 == SW1_SUCCESS && sw2 == SW2_MORE)
-    {
-        auto r = adapter->sendCommand(continueApdu);
-
-        if (r.size() < 2)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "Invalid AF response");
-
-        sw1 = r[r.size() - 2];
-        sw2 = r[r.size() - 1];
-
-        response.insert(response.end(), r.begin(), r.end() - 2);
-
-        if (sw1 != SW1_SUCCESS)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "Unexpected status during response chaining");
-
-        if (sw2 == SW2_MORE)
-            continue;
-
-        if (sw2 == SW2_OK)
-            break;
-
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "Unexpected status during response chaining");
-    }
-    if (!(sw1 == SW1_SUCCESS && sw2 == SW2_OK))
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "Expected final 9000");
-    response.push_back(sw1);
-    response.push_back(sw2);
-    return response;
-}
-
-ByteVector SAMAV2ISO7816Commands::finalizeSecureResponse(ByteVector response)
-{
-    resetIVs();
-    ++d_cmdCtr;
-    response = verifyAndDecryptResponse(response);
-    resetIVs(); // Necessary if function returns non-empty payload
-    return response;
-}
-
-//TODO merge (for single transmit func)
-ByteVector SAMAV2ISO7816Commands::transmitSecureResponseChained(const ByteVector &cmd, const sam::ChainingLayout &layout)
-{
-    if (cmd.size() < AV2_HEADER_LENGTH)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "Invalid APDU : too short");
-
-    try
-    {
-        auto protection = createfullProtectionCmd(cmd);
-        ByteVector response = sendChainedRespApdu(cmd, protection.encData, protection.mac, layout, protection.hasLe);
-        return finalizeSecureResponse(std::move(response));
-    }
-    catch (const std::exception &e)
-    {
-        secureZero(d_sessionKey);
-        secureZero(d_macSessionKey);
-        resetIVs();
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 std::string("SAM transmit failed : ") + e.what());
-    }
-}
-
-ByteVector SAMAV2ISO7816Commands::sendChainedRespApdu(
-    const ByteVector &cmd, const ByteVector &encData, const ByteVector &mac, const sam::ChainingLayout &layout, bool le)
-{
-    if (cmd.size() < AV2_HEADER_LENGTH)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "Invalid APDU : too short");
-    
-    auto adapter = getISO7816ReaderCardAdapter();
-
-    ByteVector first;
-    first.push_back(cmd[0]);
-    first.push_back(cmd[1]);
-    first.push_back(cmd[2]);
-    first.push_back(cmd[3]);
-    first.push_back(0x00);
-    first.insert(first.end(), encData.begin(), encData.begin() + encData.size());
-    first.insert(first.end(), mac.begin(), mac.begin() + 8);
-    first[AV2_LC_POS] = static_cast<unsigned char>(first.size() - AV2_HEADER_LENGTH);
-    if (le)
-        first.push_back(cmd.back());
-    ByteVector repeat;
-    repeat.push_back(cmd[0]);
-    repeat.push_back(cmd[1]);
-    repeat.push_back(0x00);
-    repeat.push_back(0x00);
-    repeat.push_back(0x00);
-
-    ByteVector response;
-    bool firstFrame = true;
-
-    while (true)
-    {
-        ByteVector result;
-        if (firstFrame)
-            result = adapter->sendCommand(first);
-        else
-            result = adapter->sendCommand(repeat);
-        if (result.size() < 2)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "Invalid response length.");
-        uint8_t sw1 = result[result.size() - 2];
-        uint8_t sw2 = result[result.size() - 1];
-
-        bool isFinal = (sw2 == 0x00);
-        bool isMore  = (sw2 == 0xAF);
-
-        if (!(sw1 == 0x90 && (isMore || isFinal)))
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "Invalid chaining status word");
-
-        if (isFinal)
-        {
-            response.insert(response.end(), result.begin(), result.end());
-            return response;
-        }
-        response.insert(response.end(), result.begin(), result.end() - 2);
-        firstFrame = false;
-    }
-    return response;
-}
-
-//TODO merge (for single transmit func)
 ByteVector SAMAV2ISO7816Commands::transmit(ByteVector cmd, bool first, bool last, bool s_mode)
 {
     if (cmd.size() < AV2_HEADER_LENGTH)
         THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "Invalid APDU : too short");
 
-    auto adapter = getISO7816ReaderCardAdapter();
-
     if (d_sessionKey.empty())
-        return adapter->sendCommand(cmd);
+        return getISO7816ReaderCardAdapter()->sendCommand(cmd);
 
-    ByteVector result;
-
-    try
-    {
-        /*if (protect == sam::HostMode::MAC) // TODO
-        {
-            protectedCmd = createMacProtectionCmd(cmd);
-            ++d_cmdCtr;
-        }*/
-        if (first || !s_mode)
-            cmd = createfullProtectionCmd(cmd).encData;
-        result = adapter->sendCommand(cmd);
-        if (first)
-            resetIVs();
-        if (first || s_mode)
-            ++d_cmdCtr;
-        if (last || !s_mode)
-            result = verifyAndDecryptResponse(result);
-        if (last)
-            resetIVs();
-        return result;
-    }
-    catch (const std::exception &e)
-    {
-        secureZero(d_sessionKey);
-        secureZero(d_macSessionKey);
-        resetIVs();
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 std::string("SAM transmit failed : ") + e.what());
-    }
+    TransmissionOptions options;
+    options.protectRequest        = first || !s_mode;
+    options.processResponse       = last || !s_mode;
+    options.resetIvBeforeResponse = first;
+    options.resetIvAfterResponse  = last;
+    options.advanceCommandCounter = first || s_mode;
+    return executeProtectedExchange(cmd, sam::ApduFormat::Standard, sam::PKI_ECC_LAYOUT, options);
 }
 
 void SAMAV2ISO7816Commands::resetIVs()
@@ -934,24 +615,292 @@ void SAMAV2ISO7816Commands::secureZero(ByteVector &vec)
         OPENSSL_cleanse(vec.data(), vec.size());
 }
 
+ByteVector SAMAV2ISO7816Commands::executeProtectedExchange(const ByteVector &cmd, sam::ApduFormat format,
+    const sam::ChainingLayout &layout, const TransmissionOptions &options)
+{
+    if (cmd.size() < AV2_HEADER_LENGTH)
+        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
+            sam::errorMessage(__func__, "APDU is shorter than the command header."));
+
+    try
+    {
+        const auto protectedApdu = prepareProtectedCommand(cmd, format);
+        const auto frames        = createApduFrames(cmd, protectedApdu, format, layout);
+        return completeSecureExchange(sendChainedFrames(frames), options);
+    }
+    catch (const std::exception &e)
+    {
+        secureZero(d_sessionKey);
+        secureZero(d_macSessionKey);
+        resetIVs();
+        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
+            sam::errorMessage(__func__, std::string("SAM transmission failed: ") + e.what()));
+    }
+}
+
+sam::ProtectedApdu SAMAV2ISO7816Commands::prepareProtectedCommand(const ByteVector &cmd, sam::ApduFormat format)
+{
+    switch (d_hostMode)
+    {
+    case sam::HostMode::Plain: return {cmd}; // Plain mode : APDU is transmitted unchanged
+    case sam::HostMode::MAC:
+    case sam::HostMode::FullProtect: return prepareProtectedApdu(cmd, format);
+    case sam::HostMode::None:
+        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, sam::errorMessage(__func__,
+                                 "Host authentication has not been established."));
+    }
+    THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, sam::errorMessage(__func__, "Invalid host mode."));
+}
+
+ByteVector SAMAV2ISO7816Commands::completeSecureExchange(ByteVector response, const TransmissionOptions &options)
+{
+    if (options.resetIvBeforeResponse)
+        resetIVs();
+    if (options.advanceCommandCounter)
+        ++d_cmdCtr;
+    if (options.processResponse)
+    {
+        switch (d_hostMode)
+        {
+        case sam::HostMode::Plain: break;
+        case sam::HostMode::MAC:
+        case sam::HostMode::FullProtect:
+            response = verifyAndDecryptResponse(std::move(response));
+            return response;
+        case sam::HostMode::None:
+            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
+                sam::errorMessage(__func__, "Host authentication has not been established."));
+        default:
+            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, sam::errorMessage(__func__, "Invalid host mode."));
+        }
+    }
+    if (options.resetIvAfterResponse)
+        resetIVs();
+
+    return response;
+}
+
+std::vector<ByteVector> SAMAV2ISO7816Commands::createApduFrames(const ByteVector &cmd,
+    const sam::ProtectedApdu &protection, sam::ApduFormat format, const sam::ChainingLayout &layout)
+{
+    if (cmd.size() < AV2_HEADER_LENGTH)
+        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "Invalid APDU : too short");
+
+    switch (d_hostMode)
+    {
+    case sam::HostMode::Plain: return createPlainChainedApduFrames(cmd, format, layout);
+    case sam::HostMode::MAC:
+    case sam::HostMode::FullProtect: return createSecureChainedApduFrames(cmd, protection, format, layout);
+    case sam::HostMode::None:
+        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
+            sam::errorMessage(__func__, "Host authentication has not been established."));
+    }
+
+    THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
+                             sam::errorMessage(__func__, "Invalid host mode."));
+}
+
+std::vector<ByteVector> SAMAV2ISO7816Commands::createSecureChainedApduFrames(
+    const ByteVector &cmd, const sam::ProtectedApdu &protection, sam::ApduFormat format,
+    const sam::ChainingLayout &layout)
+{
+    constexpr size_t MaxChunkSize = sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC;
+
+    constexpr unsigned char MoreFrame = 0xAF;
+    constexpr unsigned char LastFrame = 0x00;
+
+    const unsigned char cla = cmd[0];
+    const unsigned char ins = cmd[1];
+    const unsigned char p1  = cmd[2];
+    const unsigned char p2  = cmd[3];
+
+    const ByteVector &encData = protection.encData;
+    const ByteVector &mac     = protection.mac;
+    const bool le             = protection.hasLe;
+
+    EXCEPTION_ASSERT_WITH_LOG(mac.size() >= sam::MAC_SIZE, LibLogicalAccessException,
+        sam::errorMessage(__func__, "protected APDU MAC is shorter than expected."));
+
+    const size_t frameCount =
+        encData.empty() ? (format == sam::ApduFormat::ExtendedResponseOnly ? 1u : 0u)
+                        : (encData.size() + MaxChunkSize - 1) / MaxChunkSize;
+    std::vector<ByteVector> frames;
+    frames.reserve(frameCount);
+    auto buildFrame = [&](size_t offset, size_t chunkSize, bool isLastFrame) -> ByteVector
+    {
+        ByteVector frame;
+        frame.reserve(AV2_HEADER_LENGTH + chunkSize + (isLastFrame ? sam::MAC_SIZE : 0));
+        frame.push_back(cla);
+        frame.push_back(ins);
+        frame.push_back(p1);
+        frame.push_back(p2);
+        frame.push_back(0x00);
+        const auto it = encData.begin() + offset;
+        frame.insert(frame.end(), it, it + chunkSize);
+        if (isLastFrame)
+            frame.insert(frame.end(), mac.begin(), mac.begin() + sam::MAC_SIZE);
+        if (format != sam::ApduFormat::ExtendedResponseOnly)
+        {
+            frame[layout.lastFrameIndex] = isLastFrame ? LastFrame : MoreFrame;
+            if (offset > 0)
+                frame[layout.modeIndex] = 0x00;
+        }
+        const size_t lc = frame.size() - AV2_HEADER_LENGTH;
+        EXCEPTION_ASSERT_WITH_LOG(lc <= sam::MAX_APDU_DATA_SIZE, LibLogicalAccessException,
+            "APDU payload exceeds the maximum supported size.");
+        frame[AV2_LC_POS] = static_cast<unsigned char>(lc);
+        return frame;
+    };
+
+    size_t offset = 0;
+    for (size_t frameIndex = 0; frameIndex < frameCount; ++frameIndex)
+    {
+        const size_t remaining = encData.size() - offset;
+        const size_t chunkSize = (std::min)(MaxChunkSize, remaining);
+        const bool isLastFrame = (frameIndex + 1 == frameCount);
+        frames.emplace_back(buildFrame(offset, chunkSize, isLastFrame));
+        offset += chunkSize;
+    }
+
+    if (le && !frames.empty())
+        frames.back().push_back(cmd.back());
+
+    return frames;
+}
+
+//TODO merge parts of this function with createSecureChainedApduFrames
+std::vector<ByteVector> SAMAV2ISO7816Commands::createPlainChainedApduFrames(const ByteVector &cmd,
+    sam::ApduFormat format, const sam::ChainingLayout &layout)
+{
+    constexpr size_t MaxChunkSize = sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC;
+
+    constexpr unsigned char MoreFrame = 0xAF;
+    constexpr unsigned char LastFrame = 0x00;
+    
+    if (cmd.size() <= MaxChunkSize)
+        return {cmd};
+
+    const auto apduInfo    = getApduInfo(cmd, format);
+    const size_t dataBegin = apduInfo.hasLc ? AV2_HEADER_LENGTH : cmd.size(); //TODO optimize with cmd.size() <= MaxChunkSize
+    const size_t dataEnd   = cmd.size() - (apduInfo.hasLc ? 1u : 0u);
+    const size_t dataSize  = dataEnd - dataBegin;
+
+    const unsigned char cla = cmd[0];
+    const unsigned char ins = cmd[1];
+    const unsigned char p1  = cmd[2];
+    const unsigned char p2  = cmd[3];
+
+    bool first = true; //TODO Leave it like this for now but refactor it later
+
+    std::vector<ByteVector> frames;
+    frames.reserve((dataSize + MaxChunkSize - 1) / MaxChunkSize);
+    auto buildFrame = [&](size_t offset, size_t chunkSize, bool isLastFrame) -> ByteVector
+    {
+        ByteVector frame;
+        frame.reserve(AV2_HEADER_LENGTH + chunkSize + (isLastFrame && apduInfo.hasLe ? 1 : 0));
+        frame.push_back(cla);
+        frame.push_back(ins);
+        frame.push_back(p1);
+        frame.push_back(p2);
+        frame.push_back(0x00);
+        auto it = cmd.begin() + offset;
+        frame.insert(frame.end(), it, it + chunkSize);
+        if (format != sam::ApduFormat::ExtendedResponseOnly)
+        {
+            frame[layout.lastFrameIndex] = isLastFrame ? LastFrame : MoreFrame;
+            if (!first)
+                frame[layout.modeIndex] = 0x00;
+        }
+        const size_t lc = frame.size() - AV2_HEADER_LENGTH;
+        EXCEPTION_ASSERT_WITH_LOG(lc <= sam::MAX_APDU_DATA_SIZE, LibLogicalAccessException,
+            "APDU payload exceeds the maximum supported size.");
+        frame[AV2_LC_POS] = static_cast<unsigned char>(lc);
+        return frame;
+    };
+    size_t offset = AV2_HEADER_LENGTH;
+    while (offset < dataSize)
+    {
+        const size_t remaining = dataSize - offset;
+        const size_t chunkSize = (std::min)(MaxChunkSize, remaining);
+        const bool isLastFrame = (offset + chunkSize == dataSize);
+        frames.emplace_back(buildFrame(offset, chunkSize, isLastFrame));
+        offset += chunkSize;
+        first = false;
+    }
+    if (apduInfo.hasLe && !frames.empty())
+        frames.back().push_back(cmd.back());
+    return frames;
+}
+
+ByteVector SAMAV2ISO7816Commands::sendChainedFrames(const std::vector<ByteVector> &frames)
+{
+    EXCEPTION_ASSERT_WITH_LOG(!frames.empty(), LibLogicalAccessException,
+        sam::errorMessage(__func__, "No APDU frames to send."));
+    
+    auto adapter = getISO7816ReaderCardAdapter();
+    const ByteVector continueApdu{d_cla, frames.front()[1], 0x00, 0x00, 0x00};
+
+    ByteVector response;
+    unsigned char sw1 = 0;
+    unsigned char sw2 = 0;
+
+    auto appendResponse = [&](const ByteVector &r)
+    {
+        EXCEPTION_ASSERT_WITH_LOG(r.size() >= sam::STATUS_WORD_SIZE,
+            LibLogicalAccessException, "APDU response does not contain a status word.");
+        const auto swOffset = r.size() - sam::STATUS_WORD_SIZE;
+        sw1 = r[swOffset];
+        sw2 = r[swOffset + 1];
+        response.insert(response.end(), r.begin(), r.end() - sam::STATUS_WORD_SIZE);
+    };
+
+    for (size_t i = 0; i < frames.size(); ++i)
+    {
+        appendResponse(adapter->sendCommand(frames[i]));
+        const bool lastFrame = (i + 1 == frames.size());
+        if (!lastFrame && (sw1 != sam::sw::SuccessSW1 || sw2 != sam::sw::MoreDataSW2))
+            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
+                sam::errorMessage(__func__, "Unexpected status word after intermediate chained frame."));
+    }
+    while (sw1 == sam::sw::SuccessSW1 && sw2 == sam::sw::MoreDataSW2)
+    {
+        appendResponse(adapter->sendCommand(continueApdu));
+        if (sw1 != sam::sw::SuccessSW1 || (sw2 != sam::sw::SuccessSW2 && sw2 != sam::sw::MoreDataSW2))
+            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
+                sam::errorMessage(__func__, "Unexpected status word during response chaining."));
+    }
+    if (sw1 != sam::sw::SuccessSW1 || sw2 != sam::sw::SuccessSW2)
+        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, sam::errorMessage(__func__, "Expected 0x9000"));
+    response.push_back(sw1);
+    response.push_back(sw2);
+    return response;
+}
+
+void SAMAV2ISO7816Commands::validateSuccessResponse(const ByteVector &response, const char *caller) const
+{
+    EXCEPTION_ASSERT_WITH_LOG(response.size() >= sam::STATUS_WORD_SIZE, LibLogicalAccessException,
+        sam::errorMessage(caller, "APDU response does not contain a status word."));
+
+    const size_t swOffset = response.size() - sam::STATUS_WORD_SIZE;
+
+    EXCEPTION_ASSERT_WITH_LOG(response[swOffset] == sam::sw::SuccessSW1 && response[swOffset + 1] == sam::sw::SuccessSW2,
+                              LibLogicalAccessException, sam::errorMessage(caller, "Unexpected status word."));
+}
+
 std::shared_ptr<SAMKeyEntry<KeyEntryAV2Information, SETAV2>>
 SAMAV2ISO7816Commands::getKeyEntry(unsigned char keyno)
 {
     constexpr size_t EXPECTED_SIZE_MIN         = 14;
     constexpr size_t EXPECTED_SIZE_MAX         = 15;
-    constexpr unsigned char STATUS_SUCCESS_MSB = 0x90;
-    constexpr unsigned char STATUS_SUCCESS_LSB = 0x00;
 
-    unsigned char cmd[] = {d_cla, 0x64, keyno, 0x00, 0x00};
+    unsigned char cmd[] = {d_cla, sam::ins::key::GetKeyEntry, keyno, 0x00, 0x00};
     ByteVector cmd_vector(cmd, cmd + 5);
     ByteVector result = transmit(cmd_vector, true, true);
 
-    if ((result.size() != EXPECTED_SIZE_MIN && result.size() != EXPECTED_SIZE_MAX) ||
-        result[result.size() - 2] != STATUS_SUCCESS_MSB ||
-        result[result.size() - 1] != STATUS_SUCCESS_LSB)
-    {
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "getKeyEntry failed.");
-    }
+    EXCEPTION_ASSERT_WITH_LOG(result.size() == EXPECTED_SIZE_MIN || result.size() == EXPECTED_SIZE_MAX,
+                              LibLogicalAccessException, sam::errorMessage(__func__, "Unexpected response size."));
+
+    validateSuccessResponse(result, __func__);
 
     const size_t resultSize = result.size();
     KeyEntryAV2Information keyentryinformation;
@@ -988,56 +937,52 @@ SAMAV2ISO7816Commands::getKeyEntry(unsigned char keyno)
 
 std::shared_ptr<SAMKucEntry> SAMAV2ISO7816Commands::getKUCEntry(unsigned char kucno)
 {
-    std::shared_ptr<SAMKucEntry> kucentry(new SAMKucEntry);
-    unsigned char cmd[] = {d_cla, 0x6c, kucno, 0x00, 0x00};
-    ByteVector cmd_vector(cmd, cmd + 5);
+    auto kucentry = std::make_shared<SAMKucEntry>();
+    const unsigned char cmd[] = {d_cla, sam::ins::kuc::GetEntry, kucno, 0x00, 0x00};
+    const ByteVector cmd_vector(cmd, cmd + 5);
+    const ByteVector result = transmit(cmd_vector, true, true);
 
-    ByteVector result = transmit(cmd_vector, true, true);
+    EXCEPTION_ASSERT_WITH_LOG(result.size() == sizeof(SAMKUCEntryStruct) + sam::STATUS_WORD_SIZE, LibLogicalAccessException,
+                              sam::errorMessage(__func__, "Invalid response size."));
 
-    if (result.size() == 12 &&
-        (result[result.size() - 2] == 0x90 || result[result.size() - 1] == 0x00))
-    {
-        SAMKUCEntryStruct kucentrys;
-        memcpy(&kucentrys, &result[0], sizeof(SAMKUCEntryStruct));
-        kucentry->setKucEntryStruct(kucentrys);
-    }
-    else
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "getKUCEntry failed.");
+    validateSuccessResponse(result, __func__);
+
+    SAMKUCEntryStruct kucentrys;
+    memcpy(&kucentrys, &result[0], sizeof(SAMKUCEntryStruct));
+    kucentry->setKucEntryStruct(kucentrys);
+
     return kucentry;
 }
 
 void SAMAV2ISO7816Commands::changeKUCEntry(unsigned char kucno,
-                                           std::shared_ptr<SAMKucEntry> kucentry,
+                                           std::shared_ptr<SAMKucEntry> kucEntry,
                                            std::shared_ptr<DESFireKey> /*key*/)
 {
     if (d_sessionKey.size() == 0)
-        THROW_EXCEPTION_WITH_LOG(
-            LibLogicalAccessException,
-            "Failed: AuthentificationHost have to be done before use such command.");
+        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
+            sam::errorMessage(__func__, "AuthenticationHost must be executed before calling this command."));
 
-    unsigned char cmd[] = {d_cla, 0xcc, kucno, kucentry->getUpdateMask(), 0x06};
+    const unsigned char lc = 0x06;
+    const unsigned char cmd[] = {d_cla, sam::ins::kuc::ChangeEntry, kucno, kucEntry->getUpdateMask(), lc};
     ByteVector cmd_vector(cmd, cmd + 5);
-    cmd_vector.insert(cmd_vector.end(),
-                      reinterpret_cast<char *>(&kucentry->getKucEntryStruct()),
-                      reinterpret_cast<char *>(&kucentry->getKucEntryStruct()) + 6);
-    ByteVector result = transmit(cmd_vector, true, true);
 
-    if (result.size() >= 2 &&
-        (result[result.size() - 2] != 0x90 || result[result.size() - 1] != 0x00))
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "changeKUCEntry failed.");
+    const auto &entry      = kucEntry->getKucEntryStruct();
+    const auto *entryBytes = reinterpret_cast<const unsigned char *>(&entry);
+    cmd_vector.insert(cmd_vector.end(), entryBytes, entryBytes + lc);
+
+    const ByteVector result = transmit(cmd_vector, true, true);
+    validateSuccessResponse(result, __func__);
 }
 
-void SAMAV2ISO7816Commands::changeKeyEntry(
-    unsigned char keyno,
+void SAMAV2ISO7816Commands::changeKeyEntry(unsigned char keyno,
     std::shared_ptr<SAMKeyEntry<KeyEntryAV2Information, SETAV2>> keyentry,
     std::shared_ptr<DESFireKey> /*key*/)
 {
     if (d_sessionKey.size() == 0)
-        THROW_EXCEPTION_WITH_LOG(
-            LibLogicalAccessException,
+        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
             "Failed: AuthentificationHost have to be done before use such command.");
 
-    unsigned char proMas = keyentry->getUpdateMask();
+    const unsigned char proMas = keyentry->getUpdateMask();
 
     size_t buffer_size  = SAM_KEY_BUFFER_SIZE + sizeof(KeyEntryAV2Information);
     unsigned char *data = new unsigned char[buffer_size]();
@@ -1048,159 +993,128 @@ void SAMAV2ISO7816Commands::changeKeyEntry(
     ByteVector vectordata(data, data + buffer_size);
     delete[] data;
 
-    unsigned char cmd[] = {d_cla, 0xc1, keyno, proMas, (unsigned char)vectordata.size()};
+    const unsigned char lc = static_cast<unsigned char>(vectordata.size());
+    unsigned char cmd[] = {d_cla, sam::ins::key::ChangeKeyEntry, keyno, proMas, lc};
     ByteVector cmd_vector(cmd, cmd + 5);
     cmd_vector.insert(cmd_vector.end(), vectordata.begin(), vectordata.end());
 
-    ByteVector result = transmit(cmd_vector, true, true);
-
-    if (result.size() >= 2 &&
-        (result[result.size() - 2] != 0x90 || result[result.size() - 1] != 0x00))
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "changeKeyEntry failed.");
+    const ByteVector result = transmit(cmd_vector, true, true);
+    validateSuccessResponse(result, __func__);
 }
 
-void SAMAV2ISO7816Commands::changeKeyEntryOffline(
-    unsigned char keyno, const KeyEntryUpdateSettings &updateSettings,
+void SAMAV2ISO7816Commands::changeKeyEntryOffline(unsigned char keyno, const KeyEntryUpdateSettings &updateSettings,
     unsigned short changecnt, const ByteVector &encke)
 {
-    unsigned char proMas = SAMBasicKeyEntry::getUpdateMask(updateSettings);
+    const unsigned char proMas = SAMBasicKeyEntry::getUpdateMask(updateSettings);
 
     ByteVector vectordata;
-    vectordata.push_back(static_cast<unsigned char>((changecnt >> 8) & 0xff));
-    vectordata.push_back(static_cast<unsigned char>(changecnt & 0xff));
+    vectordata.reserve(sizeof(changecnt) + encke.size());
+    sam::appendUInt16BE(vectordata, changecnt);
     vectordata.insert(vectordata.end(), encke.begin(), encke.end());
 
-    unsigned char cmd[] = {d_cla, 0xc1, keyno, proMas, (unsigned char)vectordata.size()};
+    const unsigned char lc = static_cast<unsigned char>(vectordata.size());
+    unsigned char cmd[] = {d_cla, sam::ins::key::ChangeKeyEntry, keyno, proMas, lc};
     ByteVector cmd_vector(cmd, cmd + 5);
     cmd_vector.insert(cmd_vector.end(), vectordata.begin(), vectordata.end());
 
-    ByteVector result = transmit(cmd_vector, true, true);
-
-    if (result.size() >= 2 &&
-        (result[result.size() - 2] != 0x90 || result[result.size() - 1] != 0x00))
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "changeKeyEntryOffline failed.")
+    const ByteVector result = transmit(cmd_vector, true, true);
+    validateSuccessResponse(result, __func__);
 }
 
 void SAMAV2ISO7816Commands::changeKUCEntryOffline(
     unsigned char kucno, const KucEntryUpdateSettings &updateSettings,
     unsigned short changecnt, const ByteVector &enckuc)
 {
-    unsigned char proMas = SAMKucEntry::getUpdateMask(updateSettings);
+    const unsigned char proMas = SAMKucEntry::getUpdateMask(updateSettings);
 
     ByteVector vectordata;
-    vectordata.push_back(static_cast<unsigned char>((changecnt >> 8) & 0xff));
-    vectordata.push_back(static_cast<unsigned char>(changecnt & 0xff));
+    vectordata.reserve(sizeof(changecnt) + enckuc.size());
+    sam::appendUInt16BE(vectordata, changecnt);
     vectordata.insert(vectordata.end(), enckuc.begin(), enckuc.end());
 
-    unsigned char cmd[] = {d_cla, 0xcc, kucno, proMas, (unsigned char)vectordata.size()};
+    const unsigned char lc = static_cast<unsigned char>(vectordata.size());
+    unsigned char cmd[] = {d_cla, sam::ins::kuc::ChangeEntry, kucno, proMas, lc};
     ByteVector cmd_vector(cmd, cmd + 5);
     cmd_vector.insert(cmd_vector.end(), vectordata.begin(), vectordata.end());
 
     ByteVector result = transmit(cmd_vector, true, true);
-
-    if (result.size() >= 2 &&
-        (result[result.size() - 2] != 0x90 || result[result.size() - 1] != 0x00))
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "changeKUCEntryOffline failed.")
+    validateSuccessResponse(result, __func__);
 }
 
-void SAMAV2ISO7816Commands::disableKeyEntryOffline(unsigned char keyno,
-                                                   unsigned short changecnt,
-                                                   const ByteVector &encuid)
+void SAMAV2ISO7816Commands::disableKeyEntryOffline(unsigned char keyno, unsigned short changecnt, const ByteVector &encuid)
 {
     ByteVector vectordata;
-    vectordata.push_back(static_cast<unsigned char>((changecnt >> 8) & 0xff));
-    vectordata.push_back(static_cast<unsigned char>(changecnt & 0xff));
+    vectordata.reserve(sizeof(changecnt) + encuid.size());
+    sam::appendUInt16BE(vectordata, changecnt);
     vectordata.insert(vectordata.end(), encuid.begin(), encuid.end());
 
-    unsigned char cmd[] = {d_cla, 0xd8, keyno, 0x00, (unsigned char)vectordata.size()};
+    const unsigned char lc = static_cast<unsigned char>(vectordata.size());
+    unsigned char cmd[] = {d_cla, sam::ins::key::DisableKeyEntryOffline, keyno, 0x00, lc};
     ByteVector cmd_vector(cmd, cmd + 5);
     cmd_vector.insert(cmd_vector.end(), vectordata.begin(), vectordata.end());
 
     ByteVector result = transmit(cmd_vector, true, true);
-
-    if (result.size() >= 2 &&
-        (result[result.size() - 2] != 0x90 || result[result.size() - 1] != 0x00))
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "disableKeyEntryOffline failed.")
+    validateSuccessResponse(result, __func__);
 }
 
-ByteVector SAMAV2ISO7816Commands::dumpSecretKey(unsigned char keyno,
-                                                unsigned char keyversion,
-                                                ByteVector divInpu)
+ByteVector SAMAV2ISO7816Commands::dumpSecretKey(unsigned char keyno, unsigned char keyversion, const ByteVector& divInput)
 {
-    unsigned char p1 = 0x00;
+    const unsigned char p1 = divInput.empty() ? 0x00 : 0x02;
+    const unsigned char lc = static_cast<unsigned char>(0x02 + divInput.size());
 
-    if (divInpu.size())
-        p1 |= 0x02;
+    EXCEPTION_ASSERT_WITH_LOG(lc <= sam::MAX_APDU_DATA_SIZE, LibLogicalAccessException,
+        sam::errorMessage(__func__, "Diversification input is too large."));
 
-    unsigned char cmd[] = {
-        d_cla, 0xd6,       p1,  0x00, static_cast<unsigned char>(divInpu.size() + 0x02),
-        keyno, keyversion, 0x00};
+    unsigned char cmd[] = {d_cla, sam::ins::key::DumpSecretKey, p1, 0x00, lc, keyno, keyversion, 0x00};
     ByteVector cmd_vector(cmd, cmd + 8);
-    cmd_vector.insert(cmd_vector.end() - 1, divInpu.begin(), divInpu.end());
+    cmd_vector.insert(cmd_vector.end() - 1, divInput.begin(), divInput.end());
 
-    ByteVector result = transmit(cmd_vector);
+    const ByteVector result = transmit(cmd_vector);
+    validateSuccessResponse(result, __func__);
 
-    if (result.size() >= 2 &&
-        (result[result.size() - 2] != 0x90 || result[result.size() - 1] != 0x00))
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "dumpSecretKey failed.");
-
-    return ByteVector(result.begin(), result.end() - 2);
+    return ByteVector(result.begin(), result.end() - sam::STATUS_WORD_SIZE);
 }
 
-void SAMAV2ISO7816Commands::activateOfflineKey(unsigned char keyno,
-                                               unsigned char keyversion,
-                                               ByteVector divInpu)
+void SAMAV2ISO7816Commands::activateOfflineKey(unsigned char keyno, unsigned char keyversion, const ByteVector& divInput)
 {
-    ByteVector activateOfflineKey = {0x80,
-                                     0x01,
-                                     static_cast<unsigned char>(divInpu.size() > 0x00),
-                                     0x00,
-                                     static_cast<unsigned char>(0x02 + divInpu.size()),
-                                     keyno,
-                                     keyversion};
-    activateOfflineKey.insert(activateOfflineKey.end(), divInpu.begin(), divInpu.end());
-
-    transmit(activateOfflineKey);
+    const unsigned char p1 = static_cast<unsigned char>(divInput.size() > 0x00);
+    const unsigned char lc = static_cast<unsigned char>(0x02 + divInput.size());
+    ByteVector cmd_vector = {d_cla, sam::ins::offline::ActivateKey, p1, 0x00, lc, keyno, keyversion};
+    cmd_vector.insert(cmd_vector.end(), divInput.begin(), divInput.end());
+    const ByteVector result = transmit(cmd_vector);
+    validateSuccessResponse(result, __func__);
 }
 
-ByteVector SAMAV2ISO7816Commands::decipherOfflineData(ByteVector data)
+ByteVector SAMAV2ISO7816Commands::decipherOfflineData(const ByteVector &data)
 {
-    ByteVector decipherOfflineData = {
-        0x80, 0x0d, 0x00, 0x00, static_cast<unsigned char>(data.size()), 0x00,
-    };
+    const unsigned char lc = static_cast<unsigned char>(data.size());
+    ByteVector decipherOfflineData = {d_cla, sam::ins::offline::DecipherData, 0x00, 0x00, lc, 0x00};
     decipherOfflineData.insert(decipherOfflineData.end() - 1, data.begin(), data.end());
 
-    auto result = transmit(decipherOfflineData);
-    EXCEPTION_ASSERT_WITH_LOG(result.size() > 2, LibLogicalAccessException,
-                              "Response is too short");
-    result.resize(result.size() - 2);
+    ByteVector result = transmit(decipherOfflineData);
+    validateSuccessResponse(result, __func__);
+    result.resize(result.size() - sam::STATUS_WORD_SIZE);
     return result;
 }
 
-ByteVector SAMAV2ISO7816Commands::encipherOfflineData(ByteVector data)
+ByteVector SAMAV2ISO7816Commands::encipherOfflineData(const ByteVector &data)
 {
-    ByteVector encipherOfflineData = {
-        0x80, 0x0e, 0x00, 0x00, static_cast<unsigned char>(data.size()), 0x00,
-    };
+    const unsigned char lc = static_cast<unsigned char>(data.size());
+    ByteVector encipherOfflineData = {d_cla, sam::ins::offline::EncipherData, 0x00, 0x00, lc, 0x00};
     encipherOfflineData.insert(encipherOfflineData.end() - 1, data.begin(), data.end());
 
-    auto result = transmit(encipherOfflineData);
-    EXCEPTION_ASSERT_WITH_LOG(result.size() > 2, LibLogicalAccessException,
-                              "Response is too short");
-    result.resize(result.size() - 2);
+    ByteVector result = transmit(encipherOfflineData);
+    validateSuccessResponse(result, __func__);
+    result.resize(result.size() - sam::STATUS_WORD_SIZE);
     return result;
 }
 
 ByteVector SAMAV2ISO7816Commands::cmacOffline(const ByteVector &data)
 {
-    unsigned int block_size = 16;
-    unsigned char Rb        = 0x87;
+    unsigned char Rb = 0x87;
 
     ByteVector blankbuf;
-    blankbuf.resize(block_size, 0x00);
+    blankbuf.resize(sam::AES_BLOCK_SIZE, 0x00);
     ByteVector L = encipherOfflineData(blankbuf);
 
     ByteVector K1;
@@ -1223,9 +1137,9 @@ ByteVector SAMAV2ISO7816Commands::cmacOffline(const ByteVector &data)
         K2 = openssl::CMACCrypto::shift_string(K1, Rb);
     }
 
-    int pad = (block_size - (data.size() % block_size)) % block_size;
+    int pad = (sam::AES_BLOCK_SIZE - (data.size() % sam::AES_BLOCK_SIZE)) % sam::AES_BLOCK_SIZE;
     if (data.size() == 0)
-        pad = block_size;
+        pad = sam::AES_BLOCK_SIZE;
 
     ByteVector padded_data = data;
     if (pad > 0)
@@ -1260,9 +1174,9 @@ ByteVector SAMAV2ISO7816Commands::cmacOffline(const ByteVector &data)
     }
 
     ByteVector cmac = encipherOfflineData(padded_data);
-    if (cmac.size() > block_size)
+    if (cmac.size() > sam::AES_BLOCK_SIZE)
     {
-        cmac = ByteVector(cmac.end() - block_size, cmac.end());
+        cmac = ByteVector(cmac.end() - sam::AES_BLOCK_SIZE, cmac.end());
     }
 
     return cmac;
@@ -1271,43 +1185,37 @@ ByteVector SAMAV2ISO7816Commands::cmacOffline(const ByteVector &data)
 void SAMAV2ISO7816Commands::PKI_GenerateKeyPair(
     unsigned char keyNo, unsigned short configSettings, unsigned char keyNoCEK,
     unsigned char keyNoVCEK, unsigned char keyNoRef, const sam::AEKVAEK &accessKeys,
-    unsigned short nLen, const ByteVector &pki_e,
-    bool includeAccess)
+    unsigned short nLen, const ByteVector &pki_e, bool includeAccess)
 {
-    if (keyNo > 0x01)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_GenerateKeyPair : invalid keyNo");
-    if (nLen < 0x40 || nLen > 0x100 || (nLen % 8) != 0)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-            "PKI_GenerateKeyPair : invalid RSA modulus length (nLen).");
+    EXCEPTION_ASSERT_WITH_LOG(keyNo <= 0x01, LibLogicalAccessException,
+                              sam::errorMessage(__func__, "Invalid key number."));
 
-    const bool provideE = !pki_e.empty();
-    const unsigned short eLen =
-        provideE ? static_cast<unsigned short>(pki_e.size()) : 0x0004;
+    EXCEPTION_ASSERT_WITH_LOG(nLen >= 0x40 && nLen <= 0x100 && (nLen % 8) == 0,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid RSA modulus length (nLen)."));
 
-    if (provideE)
+    const bool provideExponent = !pki_e.empty();
+    const unsigned short eLen = provideExponent ? static_cast<unsigned short>(pki_e.size()) : 0x04;
+
+    if (provideExponent)
     {
-        if (eLen < 0x04 || eLen > 0x100 || (eLen % 4) != 0 || eLen > nLen)
-            THROW_EXCEPTION_WITH_LOG(
-                LibLogicalAccessException,
-                "PKI_GenerateKeyPair : invalid exponent length (PKI_eLen).");
-        if ((pki_e.back() & 0x01) == 0)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_GenerateKeyPair : PKI_e must be odd.");
+        EXCEPTION_ASSERT_WITH_LOG(eLen >= 0x04 && eLen <= 0x100 && (eLen % 4) == 0 && eLen <= nLen,
+            LibLogicalAccessException, sam::errorMessage(__func__, "Invalid exponent length (PKI_eLen)."));
+        EXCEPTION_ASSERT_WITH_LOG((pki_e.back() & 0x01) != 0,
+            LibLogicalAccessException, sam::errorMessage(__func__, "Exponent must be odd."));
     }
+
     unsigned short effectiveConfig = configSettings;
     if (includeAccess)
     {
-        effectiveConfig &= ~0x0004;
-        if (!accessKeys)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "AEK/VAEK required but null");
+        EXCEPTION_ASSERT_WITH_LOG(accessKeys,
+            LibLogicalAccessException, sam::errorMessage(__func__, "AEK/VAEK required but null."));
+        effectiveConfig &= static_cast<unsigned short>(~sam::pki::ConfigDisableBit);
     }
 
-    const unsigned char p1 = (provideE ? 0x01 : 0x00) | (includeAccess ? 0x02 : 0x00);
+    const unsigned char p1 = static_cast<unsigned char>(provideExponent ? 0x01 : 0x00) | (includeAccess ? 0x02 : 0x00);
 
     ByteVector payload;
-    payload.reserve(includeAccess ? 12 + pki_e.size() : 10 + pki_e.size());
+    payload.reserve((includeAccess ? 12 : 10) + pki_e.size());
     payload.push_back(keyNo);
     sam::appendUInt16BE(payload, effectiveConfig);
     payload.push_back(keyNoCEK);
@@ -1320,33 +1228,16 @@ void SAMAV2ISO7816Commands::PKI_GenerateKeyPair(
     }
     sam::appendUInt16BE(payload, nLen);
     sam::appendUInt16BE(payload, eLen);
-    if (provideE)
+    if (provideExponent)
         payload.insert(payload.end(), pki_e.begin(), pki_e.end());
 
-    ByteVector apdu;
-    apdu.push_back(d_cla);
-    apdu.push_back(0x15);
-    apdu.push_back(p1);
-    apdu.push_back(0x00);
-    if (payload.size() > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC)
-        apdu.push_back(0x00);
-    else
-        apdu.push_back(static_cast<unsigned char>(payload.size()));
+    const unsigned char lc =
+        payload.size() > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC ? 0x00 : static_cast<unsigned char>(payload.size());
+    ByteVector apdu{d_cla, sam::ins::pki::GenerateKeyPair, p1, 0x00, lc};
     apdu.insert(apdu.end(), payload.begin(), payload.end());
 
-    const ByteVector resp = transmitSecureChained(apdu, sam::ApduFormat::Extended);
-    if (resp.size() < 2)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_GenerateKeyPair : invalid response length");
-
-    const uint16_t sw = sam::parseStatusWord(resp);
-    if (sw == 0x9000)
-        return;
-    if (sw == 0x6A80)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_GenerateKeyPair : RSA key error");
-    THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                             "PKI_GenerateKeyPair : unexpected status word");
+    const ByteVector response = executeProtectedExchange(apdu, sam::ApduFormat::Extended);
+    validateSuccessResponse(response, __func__);
 }
 
 void SAMAV2ISO7816Commands::PKI_ImportKey(
@@ -1356,72 +1247,58 @@ void SAMAV2ISO7816Commands::PKI_ImportKey(
     const ByteVector &pki_dP, const ByteVector &pki_dQ, const ByteVector &pki_ipq,
     const sam::AEKVAEK &accessKeys, bool includeAccess, bool updateSettingsOnly)
 {
-    const bool hasPrivate = !pki_p.empty();
+    const bool hasPrivateKey = !pki_p.empty();
 
-    if (keyNo > (hasPrivate ? 0x01 : 0x02))
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ImportKey : keyNo out of range.");
+    EXCEPTION_ASSERT_WITH_LOG(keyNo <= (hasPrivateKey ? 0x01 : 0x02),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Key number out of range."));
 
     const size_t nLen = pki_n.size();
     const size_t eLen = pki_e.size();
 
     if (!updateSettingsOnly)
     {
-        if (pki_n.empty() || pki_e.empty())
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportKey : missing RSA components.");
+        EXCEPTION_ASSERT_WITH_LOG(!pki_n.empty() && !pki_e.empty(),
+            LibLogicalAccessException, sam::errorMessage(__func__, "Missing RSA components."));
 
-        if (nLen < 0x40 || nLen > 0x100 || (nLen % 8) != 0)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportKey : invalid modulus length.");
+        EXCEPTION_ASSERT_WITH_LOG(nLen >= 0x40 && nLen <= 0x100 && (nLen % 8) == 0,
+            LibLogicalAccessException, sam::errorMessage(__func__, "Invalid modulus length."));
 
-        if (nLen < 4 || (pki_n[0] == 0x00 && pki_n[1] == 0x00 &&
-                         pki_n[2] == 0x00 && pki_n[3] == 0x00))
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportKey : modulus MSW must not be zero.");
+        EXCEPTION_ASSERT_WITH_LOG(nLen >= 4 && !(pki_n[0] == 0x00 && pki_n[1] == 0x00 && pki_n[2] == 0x00 && pki_n[3] == 0x00),
+            LibLogicalAccessException, sam::errorMessage(__func__, "Invalid modulus MSW."));
 
-        if (eLen < 0x04 || eLen > 0x100 || (eLen % 4) != 0 || eLen > nLen)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportKey : invalid exponent length.");
+        EXCEPTION_ASSERT_WITH_LOG(eLen >= 0x04 && eLen <= 0x100 && (eLen % 4) == 0 && eLen <= nLen,
+            LibLogicalAccessException, sam::errorMessage(__func__, "Invalid exponent length."));
 
-        if ((pki_e.back() & 0x01) == 0)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportKey : exponent must be odd.");
+        EXCEPTION_ASSERT_WITH_LOG((pki_e.back() & 0x01) != 0,
+            LibLogicalAccessException, sam::errorMessage(__func__, "Exponent must be odd."));
 
-        if (pki_n[0] == 0x00)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportKey : invalid modulus MSB.");
+        EXCEPTION_ASSERT_WITH_LOG(pki_n[0] != 0x00,
+            LibLogicalAccessException, sam::errorMessage(__func__, "Invalid modulus MSB."));
     }
 
-    if (hasPrivate)
+    if (hasPrivateKey)
     {
-        if (pki_dP.size() != pki_p.size())
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportKey : dP length must equal p length.");
+        EXCEPTION_ASSERT_WITH_LOG(!pki_p.empty() && !pki_q.empty() && !pki_dP.empty() && !pki_dQ.empty() && !pki_ipq.empty(),
+            LibLogicalAccessException, sam::errorMessage(__func__, "Incomplete CRT key."));
 
-        if (pki_dQ.size() != pki_q.size())
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportKey : dQ length must equal q length.");
+        EXCEPTION_ASSERT_WITH_LOG(pki_dP.size() == pki_p.size(),
+            LibLogicalAccessException, sam::errorMessage(__func__, "dP length mismatch (must equal p length)."));
 
-        if (pki_ipq.size() != pki_q.size())
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportKey : ipq length must equal q length.");
+        EXCEPTION_ASSERT_WITH_LOG(pki_dQ.size() == pki_q.size(),
+            LibLogicalAccessException, sam::errorMessage(__func__, "dQ length mismatch (must equal q length)."));
 
-        if (pki_q.empty() || pki_dP.empty() || pki_dQ.empty() || pki_ipq.empty())
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportKey : incomplete CRT key.");
+        EXCEPTION_ASSERT_WITH_LOG(pki_ipq.size() == pki_q.size(),
+            LibLogicalAccessException, sam::errorMessage(__func__, "ipq length mismatch (must equal q length)."));
 
-        if (pki_p[0] == 0x00 || pki_q[0] == 0x00)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportKey : invalid CRT primes MSB.");
+        EXCEPTION_ASSERT_WITH_LOG(pki_p[0] != 0x00 && pki_q[0] != 0x00,
+            LibLogicalAccessException, sam::errorMessage(__func__, "Invalid CRT prime MSB."));
 
         const size_t nWords = (nLen + 3) / 4;
         const size_t pWords = (pki_p.size() + 3) / 4;
         const size_t qWords = (pki_q.size() + 3) / 4;
 
-        if ((pWords + 2 > nWords) || (qWords + 2 > nWords))
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportKey : invalid CRT size relation.");
+        EXCEPTION_ASSERT_WITH_LOG(pWords + 2 <= nWords && qWords + 2 <= nWords,
+            LibLogicalAccessException, sam::errorMessage(__func__, "Invalid CRT size relation."));
     }
 
     const bool disableRequested    = (configSettings & 0x0004) != 0;
@@ -1429,14 +1306,12 @@ void SAMAV2ISO7816Commands::PKI_ImportKey(
 
     if (includeAccess)
     {
-        if (disableRequested)
-            LOG(LogLevel::WARNINGS)
-                << "PKI_ImportKey : overriding PKI_SET disable bit due to AEK.";
-        effectiveConfig &= ~0x0004;
+        EXCEPTION_ASSERT_WITH_LOG(accessKeys,
+            LibLogicalAccessException, sam::errorMessage(__func__, "AEK/VAEK required."));
 
-        if (!accessKeys)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportKey : AEK/VAEK required.");
+        if ((effectiveConfig & sam::pki::ConfigDisableBit) != 0)
+            LOG(LogLevel::WARNINGS) << sam::errorMessage(__func__, "Overriding PKI_SET disable bit due to AEK.");
+        effectiveConfig &= static_cast<unsigned short>(~sam::pki::ConfigDisableBit);
     }
 
     const unsigned char p1 = (updateSettingsOnly ? 0x01 : 0x00) | (includeAccess ? 0x02 : 0x00);
@@ -1456,17 +1331,16 @@ void SAMAV2ISO7816Commands::PKI_ImportKey(
     {
         sam::appendUInt16BE(payload, static_cast<uint16_t>(nLen));
         sam::appendUInt16BE(payload, static_cast<uint16_t>(eLen));
-        if (hasPrivate)
+        if (hasPrivateKey)
         {
-            if (pki_p.size() > 0xFFFF || pki_q.size() > 0xFFFF)
-                THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                         "PKI_ImportKey : invalid CRT length overflow.");
+            EXCEPTION_ASSERT_WITH_LOG(pki_p.size() <= 0xFFFF && pki_q.size() <= 0xFFFF,
+                                      LibLogicalAccessException, sam::errorMessage(__func__, "CRT size overflow."));
             sam::appendUInt16BE(payload, static_cast<uint16_t>(pki_p.size()));
             sam::appendUInt16BE(payload, static_cast<uint16_t>(pki_q.size()));
         }
         payload.insert(payload.end(), pki_n.begin(), pki_n.end());
         payload.insert(payload.end(), pki_e.begin(), pki_e.end());
-        if (hasPrivate)
+        if (hasPrivateKey)
         {
             payload.insert(payload.end(), pki_p.begin(), pki_p.end());
             payload.insert(payload.end(), pki_q.begin(), pki_q.end());
@@ -1476,96 +1350,41 @@ void SAMAV2ISO7816Commands::PKI_ImportKey(
         }
     }
 
-    ByteVector apdu;
-    apdu.push_back(d_cla);
-    apdu.push_back(0x19);
-    apdu.push_back(p1);
-    apdu.push_back(0x00);
-    apdu.push_back(payload.size() > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC ? 0x00 : static_cast<unsigned char>(payload.size()));
+    const unsigned char lc =
+        payload.size() > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC ? 0x00 : static_cast<unsigned char>(payload.size());
+    ByteVector apdu{d_cla, sam::ins::pki::ImportKey, p1, 0x00, lc};
     apdu.insert(apdu.end(), payload.begin(), payload.end());
 
-    const ByteVector resp = transmitSecureChained(apdu, sam::ApduFormat::Extended);
-    if (resp.size() < 2)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ImportKey : invalid response length");
-    const uint16_t sw = sam::parseStatusWord(resp);
-
-    if (sw == 0x9000)
-        return;
-    if (sw == 0x6A80)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ImportKey : Key ref out of range.");
-
-    THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                             "PKI_ImportKey : unexpected status word.");
+    const ByteVector response = executeProtectedExchange(apdu, sam::ApduFormat::Extended);
+    validateSuccessResponse(response, __func__);
 }
 
-ByteVector SAMAV2ISO7816Commands::PKI_ExportPrivateKey(unsigned char keyNo,
-                                                       bool returnAEK)
+ByteVector SAMAV2ISO7816Commands::PKI_ExportPrivateKey(unsigned char keyNo, bool returnAEK)
 {
-    //constexpr size_t MIN_RESPONSE_SIZE = 3;
-    //constexpr size_t MIN_KEY_DATA_SIZE = 13;
+    EXCEPTION_ASSERT_WITH_LOG(keyNo <= 0x01,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid key reference number."));
 
-    if (keyNo > 0x01)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ExportPrivateKey : invalid key reference number.");
+    const unsigned char returnAekFlag = static_cast<unsigned char>(returnAEK ? 0x80 : 0x00);
+    ByteVector apdu{d_cla, sam::ins::pki::ExportPrivateKey, keyNo, returnAekFlag, 0x00};
+    ByteVector response = executeProtectedExchange(apdu, sam::ApduFormat::ExtendedResponseOnly);
+    validateSuccessResponse(response, __func__);
 
-    ByteVector apdu;
-    apdu.reserve(5);
-    apdu.push_back(d_cla);
-    apdu.push_back(0x1F);
-    apdu.push_back(keyNo);
-    apdu.push_back(returnAEK ? 0x80 : 0x00);
-    apdu.push_back(0x00);
-
-    ByteVector resp = transmitSecureResponseChained(apdu);
-    if (resp.size() < 2)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ExportPrivateKey : invalid response length");
-    const uint16_t sw = sam::parseStatusWord(resp);
-    if (sw == 0x9000)
-    {
-        resp.resize(resp.size() - 2);
-        return resp;
-    }
-    if (sw == 0x6986)
-        THROW_EXCEPTION_WITH_LOG(
-            LibLogicalAccessException,
-            "PKI_ExportPrivateKey : private key export not allowed.");
-
-    THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                             "PKI_ExportPrivateKey : unexpected status word.");
+    response.resize(response.size() - sam::STATUS_WORD_SIZE);
+    return response;
 }
 
 ByteVector SAMAV2ISO7816Commands::PKI_ExportPublicKey(unsigned char keyNo, bool returnAEK)
 {
-    if (keyNo > 0x02)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ExportPublicKey : keyNo out of range.");
+    EXCEPTION_ASSERT_WITH_LOG(keyNo <= 0x02,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Key number out of range."));
 
-    ByteVector apdu;
-    apdu.reserve(5);
-    apdu.push_back(d_cla);
-    apdu.push_back(0x18);
-    apdu.push_back(keyNo);
-    apdu.push_back(returnAEK ? 0x80 : 0x00);
-    apdu.push_back(0x00);
+    const unsigned char returnAekFlag = static_cast<unsigned char>(returnAEK ? 0x80 : 0x00);
+    ByteVector apdu{d_cla, sam::ins::pki::ExportPublicKey, keyNo, returnAekFlag, 0x00};
+    ByteVector response = executeProtectedExchange(apdu, sam::ApduFormat::ExtendedResponseOnly);
+    validateSuccessResponse(response, __func__);
 
-    ByteVector resp = transmitSecureResponseChained(apdu);
-    if (resp.size() < 2)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ExportPublicKey : invalid response size.");
-    const uint16_t sw = sam::parseStatusWord(resp);
-    if (sw == 0x9000)
-    {
-        resp.resize(resp.size() - 2);
-        return resp;
-    }
-    if (sw == 0x6986)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-            "PKI_ExportPublicKey : export not allowed.");
-
-    THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, "PKI_ExportPublicKey : unexpected status word.");
+    response.resize(response.size() - sam::STATUS_WORD_SIZE);
+    return response;
 }
 
 ByteVector SAMAV2ISO7816Commands::buildPlaintext(uint16_t changeCtr, const std::vector<std::shared_ptr<SAMBasicKeyEntry>> &entries)
@@ -1806,7 +1625,7 @@ ByteVector SAMAV2ISO7816Commands::PKI_UpdateKeyEntries(
     {
         ByteVector apdu;
         apdu.push_back(d_cla);
-        apdu.push_back(0x1D);
+        apdu.push_back(sam::ins::pki::UpdateKeyEntries);
         apdu.push_back(p1);
         apdu.push_back(0x00);
         if (data.size() > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC)
@@ -1820,13 +1639,13 @@ ByteVector SAMAV2ISO7816Commands::PKI_UpdateKeyEntries(
     };
 
     const ByteVector fullPayload = buildAPDU(payload);
-    ByteVector resp = transmitSecureChained(fullPayload, sam::ApduFormat::ExtendedWithLe);
-    if (resp.size() < 2)
+    ByteVector resp = executeProtectedExchange(fullPayload, sam::ApduFormat::ExtendedWithLe);
+    if (resp.size() < sam::STATUS_WORD_SIZE)
         THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
                                  "PKI_UpdateKeyEntries : response too short");
 
     const uint16_t sw = sam::parseStatusWord(resp);
-    resp.resize(resp.size() - 2);
+    resp.resize(resp.size() - sam::STATUS_WORD_SIZE);
     if (sw == 0x9000)
         return resp;
     if (sw == 0x6A80)
@@ -1842,44 +1661,34 @@ ByteVector SAMAV2ISO7816Commands::PKI_EncipherKeyEntries(
     const std::vector<std::pair<unsigned char, unsigned char>> &keyEntries,
     const ByteVector &divInput)
 {
-    if (!sam::isSupportedHashAlgo(hashAlgo))
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_EncipherKeyEntries : unsupported or RFU hash algorithm.");
+    EXCEPTION_ASSERT_WITH_LOG(sam::isSupportedHashAlgo(hashAlgo),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Unsupported or RFU hash algorithm."));
 
-    if (keyEntries.empty() || keyEntries.size() > 3)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_EncipherKeyEntries : 1 to 3 key entries allowed");
+    EXCEPTION_ASSERT_WITH_LOG(!keyEntries.empty() && keyEntries.size() <= 3,
+        LibLogicalAccessException, sam::errorMessage(__func__, "1 to 3 key entries are allowed."));
 
-    if (!divInput.empty() && divInput.size() > 31)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_EncipherKeyEntries : DivInput must be 1...31 bytes");
+    EXCEPTION_ASSERT_WITH_LOG(divInput.empty() || divInput.size() <= 31,
+        LibLogicalAccessException, sam::errorMessage(__func__, "DivInput must be between 1 and 31 bytes."));
 
-    if (keyNoEnc > 0x02)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_EncipherKeyEntries : invalid keyNoEnc.");
+    EXCEPTION_ASSERT_WITH_LOG(keyNoEnc <= 0x02,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid keyNoEnc."));
 
-    if (keyNoSign > 0x01)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_EncipherKeyEntries : invalid keyNoSign.");
+    EXCEPTION_ASSERT_WITH_LOG(keyNoSign <= 0x01,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid keyNoSign."));
 
-    if (keyNoDec > 0x01)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_EncipherKeyEntries : invalid keyNoDec.");
+    EXCEPTION_ASSERT_WITH_LOG(keyNoDec <= 0x01,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid keyNoDec."));
 
-    if (keyNoVerif > 0x02)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_EncipherKeyEntries : invalid keyNoVerif.");
+    EXCEPTION_ASSERT_WITH_LOG(keyNoVerif <= 0x02,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid keyNoVerif."));
 
-    for (const auto &k : keyEntries)
-    {
-        if (k.first > 0x7F || k.second > 0x7F)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_EncipherKeyEntries : invalid key entry pair");
-    }
+    for (const auto &entry : keyEntries)
+        EXCEPTION_ASSERT_WITH_LOG(entry.first <= 0x7F && entry.second <= 0x7F,
+                                  LibLogicalAccessException, sam::errorMessage(__func__, "Invalid key entry pair."));
 
     const unsigned char p1 = (hashAlgo & 0x03) |
                              (static_cast<unsigned char>(keyEntries.size()) << 2) |
-                             (!divInput.empty() ? 0x10 : 0x00);
+                             (divInput.empty() ? 0x00 : 0x10);
 
     ByteVector payload;
     payload.reserve(6 + keyEntries.size() * 2 + divInput.size());
@@ -1896,157 +1705,94 @@ ByteVector SAMAV2ISO7816Commands::PKI_EncipherKeyEntries(
     if (!divInput.empty())
         payload.insert(payload.end(), divInput.begin(), divInput.end());
 
-    ByteVector apdu;
-    apdu.push_back(d_cla);
-    apdu.push_back(0x12);
-    apdu.push_back(p1);
-    apdu.push_back(0x00);
-    if (payload.size() > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC)
-        apdu.push_back(0x00);
-    else
-        apdu.push_back(static_cast<unsigned char>(payload.size()));
+    const unsigned char lc =
+        payload.size() > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC ? 0x00 : static_cast<unsigned char>(payload.size());
+    ByteVector apdu{d_cla, sam::ins::pki::EncipherKeyEntries, p1, 0x00, lc};
     apdu.insert(apdu.end(), payload.begin(), payload.end());
     apdu.push_back(0x00);
 
-    ByteVector resp = transmitSecureChained(apdu, sam::ApduFormat::ExtendedWithLe);
-    if (resp.size() < 2)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_EncipherKeyEntries : response too short.");
+    ByteVector response = executeProtectedExchange(apdu, sam::ApduFormat::ExtendedWithLe);
+    validateSuccessResponse(response, __func__);
 
-    const uint16_t sw = sam::parseStatusWord(resp);
-
-    if (sw == 0x9000)
-    {
-        resp.resize(resp.size() - 2);
-        return resp;
-    }
-
-    if (sw == 0x6A80)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_EncipherKeyEntries : at least one selected PKI key is not "
-                                 "reserved for personalization.");
-
-    THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                             "PKI_EncipherKeyEntries : unexpected status word.");
+    response.resize(response.size() - sam::STATUS_WORD_SIZE);
+    return response;
 }
 
-ByteVector SAMAV2ISO7816Commands::PKI_GenerateHash(unsigned char hashAlgo,
-                                                   const ByteVector &message)
+ByteVector SAMAV2ISO7816Commands::PKI_GenerateHash(unsigned char hashAlgo, const ByteVector &message)
 {
-    if (!sam::isSupportedHashAlgo(hashAlgo))
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_GenerateHash : unsupported or RFU hash algorithm.");
+    EXCEPTION_ASSERT_WITH_LOG(sam::isSupportedHashAlgo(hashAlgo),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Unsupported or RFU hash algorithm."));
 
-    if (message.empty())
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_GenerateHash : message cannot be empty.");
+    EXCEPTION_ASSERT_WITH_LOG(!message.empty(),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Message cannot be empty."));
 
     const uint32_t messageLen = static_cast<uint32_t>(message.size());
+    const size_t payloadSize  = sizeof(messageLen) + message.size();
+    const unsigned char lc =
+        payloadSize > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC ? 0x00 : static_cast<unsigned char>(payloadSize);
 
     ByteVector apdu;
-    apdu.reserve(5 + 4 + message.size() + 1);
+    apdu.reserve(5 + payloadSize + 1);
     apdu.push_back(d_cla);
-    apdu.push_back(0x17);
+    apdu.push_back(sam::ins::pki::GenerateHash);
     apdu.push_back(hashAlgo);
     apdu.push_back(0x00);
-    const size_t lc = 4 + message.size();
-    if (lc > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC)
-        apdu.push_back(0x00);
-    else
-        apdu.push_back(static_cast<unsigned char>(lc));
+    apdu.push_back(lc);
     sam::appendUInt32BE(apdu, messageLen);
     apdu.insert(apdu.end(), message.begin(), message.end());
     apdu.push_back(0x00);
 
-    ByteVector response = transmitSecureChained(apdu, sam::ApduFormat::ExtendedWithLe);
+    ByteVector response = executeProtectedExchange(apdu, sam::ApduFormat::ExtendedWithLe);
+    validateSuccessResponse(response, __func__);
 
-    if (response.size() < 2)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_GenerateHash : invalid response size.");
+    EXCEPTION_ASSERT_WITH_LOG(response.size() == sam::expectedHashSize(hashAlgo) + sam::STATUS_WORD_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid hash length."));
 
-    if (response.size() != sam::expectedHashSize(hashAlgo) + 2)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_GenerateHash : invalid hash length.");
-
-    const uint16_t sw = sam::parseStatusWord(response);
-    if (sw != 0x9000)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_GenerateHash : unexpected status word.");
-
-    response.resize(response.size() - 2);
+    response.resize(response.size() - sam::STATUS_WORD_SIZE);
     return response;
 }
 
-void SAMAV2ISO7816Commands::PKI_GenerateSignature(unsigned char hashAlgo,
-                                                  unsigned char keyNoSign,
-                                                  const ByteVector &hash)
+void SAMAV2ISO7816Commands::PKI_GenerateSignature(unsigned char hashAlgo, unsigned char keyNoSign, const ByteVector &hash)
 {
-    if (!sam::isSupportedHashAlgo(hashAlgo))
-        THROW_EXCEPTION_WITH_LOG(
-            LibLogicalAccessException,
-            "PKI_GenerateSignature : unsupported or RFU hash algorithm.");
+    EXCEPTION_ASSERT_WITH_LOG(sam::isSupportedHashAlgo(hashAlgo),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Unsupported or RFU hash algorithm."));
 
-    if (keyNoSign > 0x01)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_GenerateSignature : invalid key number.");
+    EXCEPTION_ASSERT_WITH_LOG(keyNoSign <= 0x01,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid key number."));
 
     const size_t expectedSize = sam::expectedHashSize(hashAlgo);
 
-    if (hash.size() != expectedSize)
-        THROW_EXCEPTION_WITH_LOG(
-            LibLogicalAccessException,
-            "PKI_GenerateSignature : invalid hash size for selected algorithm.");
+    EXCEPTION_ASSERT_WITH_LOG(hash.size() == expectedSize,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid hash size for selected algorithm."));
+
+    const unsigned char lc = static_cast<unsigned char>(1 + hash.size());
 
     ByteVector apdu;
-    apdu.reserve(5 + 1 + hash.size());
+    apdu.reserve(5 + lc);
     apdu.push_back(d_cla);
-    apdu.push_back(0x16);
+    apdu.push_back(sam::ins::pki::GenerateSignature);
     apdu.push_back(hashAlgo);
     apdu.push_back(0x00);
-
-    const size_t lc = 1 + hash.size();
-    if (lc > 1 + expectedSize)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_GenerateSignature : payload too large.");
-
-    apdu.push_back(static_cast<unsigned char>(lc));
+    apdu.push_back(lc);
     apdu.push_back(keyNoSign);
     apdu.insert(apdu.end(), hash.begin(), hash.end());
 
     const ByteVector response = transmit(apdu, true, true);
-
-    if (response.size() < 2)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_GenerateSignature : invalid response size.");
-
-    const uint16_t sw = sam::parseStatusWord(response);
-
-    if (sw != 0x9000)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_GenerateSignature : unexpected status word.");
-
-    return;
+    validateSuccessResponse(response, __func__);
 }
 
 ByteVector SAMAV2ISO7816Commands::PKI_SendSignature()
 {
     constexpr size_t MIN_SIG_SIZE = 8;
     constexpr size_t MAX_SIG_SIZE = 256;
-    ByteVector signature = transmit({d_cla, 0x1A, 0x00, 0x00, 0x00}, true, true);
 
-    if (signature.size() < 2)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_SendSignature : invalid response size.");
+    ByteVector signature = transmit({d_cla, sam::ins::pki::SendSignature, 0x00, 0x00, 0x00}, true, true);
+    validateSuccessResponse(signature, __func__);
 
-    if (sam::parseStatusWord(signature) != 0x9000)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_SendSignature : unexpected status word.");
+    signature.resize(signature.size() - sam::STATUS_WORD_SIZE);
 
-    signature.resize(signature.size() - 2);
-
-    if (signature.size() < MIN_SIG_SIZE || signature.size() > MAX_SIG_SIZE)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_SendSignature : invalid signature size.");
+    EXCEPTION_ASSERT_WITH_LOG(signature.size() >= MIN_SIG_SIZE && signature.size() <= MAX_SIG_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid signature size."));
 
     return signature;
 }
@@ -2056,24 +1802,17 @@ void SAMAV2ISO7816Commands::PKI_VerifySignature(unsigned char hashAlgo,
                                                 const ByteVector &hash,
                                                 const ByteVector &signature)
 {
-    if (!sam::isSupportedHashAlgo(hashAlgo))
-        THROW_EXCEPTION_WITH_LOG(
-            LibLogicalAccessException,
-            "PKI_VerifySignature : unsupported or RFU hash algorithm.");
+    EXCEPTION_ASSERT_WITH_LOG(sam::isSupportedHashAlgo(hashAlgo),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Unsupported or RFU hash algorithm."));
 
-    if (keyNoVerif > 0x02)
-        THROW_EXCEPTION_WITH_LOG(
-            LibLogicalAccessException,
-            "PKI_VerifySignature : invalid verification key number.");
+    EXCEPTION_ASSERT_WITH_LOG(keyNoVerif <= 0x02,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid verification key number."));
 
-    if (hash.size() != sam::expectedHashSize(hashAlgo))
-        THROW_EXCEPTION_WITH_LOG(
-            LibLogicalAccessException,
-            "PKI_VerifySignature : invalid hash size for selected algorithm.");
+    EXCEPTION_ASSERT_WITH_LOG(hash.size() == sam::expectedHashSize(hashAlgo),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid hash size for selected algorithm."));
 
-    if (signature.empty())
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_VerifySignature : signature cannot be empty.");
+    EXCEPTION_ASSERT_WITH_LOG(!signature.empty(),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Signature cannot be empty."));
 
     ByteVector payload;
     payload.reserve(1 + hash.size() + signature.size());
@@ -2081,76 +1820,57 @@ void SAMAV2ISO7816Commands::PKI_VerifySignature(unsigned char hashAlgo,
     payload.insert(payload.end(), hash.begin(), hash.end());
     payload.insert(payload.end(), signature.begin(), signature.end());
 
+    const unsigned char lc =
+        payload.size() > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC ? 0x00 : static_cast<unsigned char>(payload.size());
     ByteVector apdu;
     apdu.reserve(5 + payload.size());
     apdu.push_back(d_cla);
-    apdu.push_back(0x1B);
+    apdu.push_back(sam::ins::pki::VerifySignature);
     apdu.push_back(hashAlgo);
     apdu.push_back(0x00);
-    if (payload.size() > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC)
-        apdu.push_back(0x00);
-    else
-        apdu.push_back(static_cast<unsigned char>(payload.size()));
+    apdu.push_back(lc);
     apdu.insert(apdu.end(), payload.begin(), payload.end());
 
-    const ByteVector response = transmitSecureChained(apdu, sam::ApduFormat::Extended);
-
-    if (response.size() < 2)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_VerifySignature : invalid response size.");
-
-    if (sam::parseStatusWord(response) != 0x9000)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_VerifySignature : unexpected status word.");
-
-    return;
+    const ByteVector response = executeProtectedExchange(apdu, sam::ApduFormat::Extended);
+    validateSuccessResponse(response, __func__);
 }
 
 ByteVector SAMAV2ISO7816Commands::PKI_EncipherData(unsigned char hashAlgo,
                                                    unsigned char keyNoEnc,
                                                    const ByteVector &plainData)
 {
-    if (!sam::isSupportedHashAlgo(hashAlgo))
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_EncipherData : unsupported or RFU hash algorithm.");
+    EXCEPTION_ASSERT_WITH_LOG(sam::isSupportedHashAlgo(hashAlgo),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Unsupported or RFU hash algorithm."));
 
-    if (keyNoEnc > 0x02)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_EncipherData : invalid encryption key number.");
+    EXCEPTION_ASSERT_WITH_LOG(keyNoEnc <= 0x02,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid encryption key number."));
 
-    if (plainData.empty())
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_EncipherData : empty plaintext.");
+    EXCEPTION_ASSERT_WITH_LOG(!plainData.empty(), LibLogicalAccessException,
+                              sam::errorMessage(__func__, "Empty plaintext."));
 
-    const unsigned char p1 = (hashAlgo & 0x03);
-    const size_t lc = 1 + plainData.size();
+    const unsigned char p1 = hashAlgo & 0x03;
+    const size_t payloadSize = 1 + plainData.size();
+    const unsigned char lc =
+        payloadSize > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC ? 0x00 : static_cast<unsigned char>(payloadSize);
 
     ByteVector apdu;
-    apdu.reserve(5 + lc + 1);
+    apdu.reserve(5 + payloadSize + 1);
     apdu.push_back(d_cla);
-    apdu.push_back(0x13);
+    apdu.push_back(sam::ins::pki::EncipherData);
     apdu.push_back(p1);
     apdu.push_back(0x00);
-    apdu.push_back(static_cast<unsigned char>(lc));
+    apdu.push_back(lc);
     apdu.push_back(keyNoEnc);
     apdu.insert(apdu.end(), plainData.begin(), plainData.end());
     apdu.push_back(0x00);
 
-    ByteVector encData = transmitSecureChained(apdu);
+    ByteVector encData = executeProtectedExchange(apdu, sam::ApduFormat::ExtendedWithLe);
+    validateSuccessResponse(encData, __func__);
 
-    if (encData.size() < 2)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_EncipherData : response too short");
+    encData.resize(encData.size() - sam::STATUS_WORD_SIZE);
 
-    encData.resize(encData.size() - 2);
-
-    if (sam::parseStatusWord(encData) != 0x9000)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_EncipherData : unexpected status word.");
-
-    if (encData.empty())
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_EncipherData : empty encrypted data");
+    EXCEPTION_ASSERT_WITH_LOG(!encData.empty(),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Empty encrypted data returned."));
 
     return encData;
 }
@@ -2159,50 +1879,38 @@ ByteVector SAMAV2ISO7816Commands::PKI_DecipherData(unsigned char hashAlgo,
                                                    unsigned char keyNoDec,
                                                    const ByteVector &encData)
 {
-    if (!sam::isSupportedHashAlgo(hashAlgo))
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_DecipherData : unsupported or RFU hash algorithm.");
+    EXCEPTION_ASSERT_WITH_LOG(sam::isSupportedHashAlgo(hashAlgo),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Unsupported or RFU hash algorithm."));
 
-    if (keyNoDec > 0x01)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_DecipherData : invalid key number.");
+    EXCEPTION_ASSERT_WITH_LOG(keyNoDec <= 0x01,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid key number."));
 
-    if (encData.empty())
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_DecipherData : empty encrypted data");
+    EXCEPTION_ASSERT_WITH_LOG(!encData.empty(),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Empty encrypted data."));
 
-    const unsigned char p1 = (hashAlgo & 0x03);
-    const size_t lc = 1 + encData.size();
+    const unsigned char p1 = hashAlgo & 0x03;
+    const size_t payloadSize = 1 + encData.size();
+    const unsigned char lc =
+        payloadSize > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC ? 0x00 : static_cast<unsigned char>(payloadSize);
 
     ByteVector apdu;
-    apdu.reserve(5 + lc + 1);
+    apdu.reserve(5 + payloadSize + 1);
     apdu.push_back(d_cla);
-    apdu.push_back(0x14);
+    apdu.push_back(sam::ins::pki::DecipherData);
     apdu.push_back(p1);
     apdu.push_back(0x00);
-    if (lc > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC)
-        apdu.push_back(0x00);
-    else
-        apdu.push_back(static_cast<unsigned char>(lc));
+    apdu.push_back(lc);
     apdu.push_back(keyNoDec);
     apdu.insert(apdu.end(), encData.begin(), encData.end());
     apdu.push_back(0x00);
 
-    ByteVector plainData = transmitSecureChained(apdu, sam::ApduFormat::ExtendedWithLe);
+    ByteVector plainData = executeProtectedExchange(apdu, sam::ApduFormat::ExtendedWithLe);
+    validateSuccessResponse(plainData, __func__);
 
-    if (plainData.size() < 2)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_DecipherData : invalid response size.");
+    plainData.resize(plainData.size() - sam::STATUS_WORD_SIZE);
 
-    if (sam::parseStatusWord(plainData) != 0x9000)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_DecipherData : unexpected status word.");
-
-    plainData.resize(plainData.size() - 2);
-
-    if (plainData.empty())
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_DecipherData : empty plaintext returned.");
+    EXCEPTION_ASSERT_WITH_LOG(!plainData.empty(),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Empty plaintext returned."));
 
     return plainData;
 }
@@ -2212,9 +1920,8 @@ void SAMAV2ISO7816Commands::PKI_ImportEccKey(
     unsigned char keyNoVCEK, unsigned char keyNoKUC, unsigned char keyNoAEK,
     unsigned char keyNoVAEK, const ByteVector &eccPublicKey, bool settingsOnly)
 {
-    if (keyNo > 0x07)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ImportEccKey : invalid keyNo (0...7)");
+    EXCEPTION_ASSERT_WITH_LOG(keyNo <= 0x07,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid keyNo (must be 0...7)."));
 
     constexpr size_t PKI_IMPORT_ECC_MAX_PAYLOAD = 0x4B;
 
@@ -2232,63 +1939,42 @@ void SAMAV2ISO7816Commands::PKI_ImportEccKey(
 
     if (!settingsOnly)
     {
-        if (eccPublicKey.empty())
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportEccKey : eccPublicKey must be provided "
-                                     "when settingsOnly = false");
+        EXCEPTION_ASSERT_WITH_LOG(!eccPublicKey.empty(), LibLogicalAccessException,
+            sam::errorMessage(__func__, "ECC public key must be provided when settingsOnly is false."));
 
-        if (eccPublicKey[0] != 0x04)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportEccKey : ECC public key must start with "
-                                     "0x04 (uncompressed format)");
+        EXCEPTION_ASSERT_WITH_LOG(eccPublicKey[0] == 0x04, LibLogicalAccessException,
+            sam::errorMessage(__func__, "ECC public key must start with 0x04 (uncompressed format)."));
 
         const size_t keySize = eccPublicKey.size();
 
-        if (keySize < 33 || keySize > 65)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportEccKey : invalid ECC public key length "
-                                     "(must be 33...65 bytes)");
+        EXCEPTION_ASSERT_WITH_LOG(keySize >= 33 && keySize <= 65, LibLogicalAccessException,
+            sam::errorMessage(__func__, "Invalid ECC public key length (must be 33...65 bytes)."));
 
         const unsigned short coordSize = static_cast<unsigned short>((keySize - 1) / 2);
 
-        if (coordSize * 2 + 1 != keySize)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportEccKey : malformed ECC point structure");
+        EXCEPTION_ASSERT_WITH_LOG((coordSize * 2 + 1) == keySize,
+            LibLogicalAccessException, sam::errorMessage(__func__, "Malformed ECC point structure."));
 
         sam::appendUInt16BE(payload, coordSize);
         payload.insert(payload.end(), eccPublicKey.begin(), eccPublicKey.end());
     }
 
-    if (payload.size() > PKI_IMPORT_ECC_MAX_PAYLOAD)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ImportEccKey : payload too large");
+    EXCEPTION_ASSERT_WITH_LOG(payload.size() <= PKI_IMPORT_ECC_MAX_PAYLOAD,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Payload too large."));
+
+    const unsigned char lc = static_cast<unsigned char>(payload.size());
 
     ByteVector apdu;
     apdu.reserve(5 + payload.size());
     apdu.push_back(d_cla);
-    apdu.push_back(0x21);
+    apdu.push_back(sam::ins::pki::ImportECCKey);
     apdu.push_back(p1);
     apdu.push_back(0x00);
-    apdu.push_back(static_cast<unsigned char>(payload.size()));
+    apdu.push_back(lc);
     apdu.insert(apdu.end(), payload.begin(), payload.end());
 
-    const ByteVector resp = transmit(apdu, true, true);
-
-    if (resp.size() < 2)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ImportEccKey : response too short");
-
-    const uint16_t sw = sam::parseStatusWord(resp);
-
-    if (sw == 0x9000)
-        return;
-
-    if (sw == 0x6A80)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ImportEccKey : invalid key reference");
-
-    THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                             "PKI_ImportEccKey : unexpected status word");
+    const ByteVector response = transmit(apdu, true, true);
+    validateSuccessResponse(response, __func__);
 }
 
 void SAMAV2ISO7816Commands::PKI_ImportEccCurve(unsigned char curveNo, unsigned char keyNoCCK,
@@ -2296,14 +1982,11 @@ void SAMAV2ISO7816Commands::PKI_ImportEccCurve(unsigned char curveNo, unsigned c
                                                const ByteVector &eccCurve,
                                                bool settingsOnly)
 {
+    EXCEPTION_ASSERT_WITH_LOG(curveNo <= 0x03,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Curve number out of range (0x00...0x03)."));
 
-    if (curveNo > 0x03)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-            "PKI_ImportEccCurve : curveNo out of range (0x00...0x03)");
-
-    if (!(keyNoCCK == 0xFE || keyNoCCK == 0xFF || keyNoCCK <= 0x7F))
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "pkiImportEccCurve : invalid keyNoCCK");
+    EXCEPTION_ASSERT_WITH_LOG(keyNoCCK == 0xFE || keyNoCCK == 0xFF || keyNoCCK <= 0x7F,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid keyNoCCK."));
 
     const unsigned char p1 = settingsOnly ? 0x01 : 0x00;
 
@@ -2315,40 +1998,33 @@ void SAMAV2ISO7816Commands::PKI_ImportEccCurve(unsigned char curveNo, unsigned c
 
     if (!settingsOnly)
     {
-        if (eccCurve.empty())
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                "PKI_ImportEccCurve : ECC curve data required when settingsOnly = false");
+        EXCEPTION_ASSERT_WITH_LOG(!eccCurve.empty(), LibLogicalAccessException,
+            sam::errorMessage(__func__, "ECC curve data required when settingsOnly is false."));
 
-        if (eccCurve.size() < 2)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportEccCurve : ECC curve data too short");
+        EXCEPTION_ASSERT_WITH_LOG(eccCurve.size() >= 2,
+            LibLogicalAccessException, sam::errorMessage(__func__, "ECC curve data too short."));
 
         const unsigned char eccN = eccCurve[0];
         const unsigned char eccM = eccCurve[1];
 
-        if (eccN < 0x10 || eccN > 0x20)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                "PKI_ImportEccCurve : ECC_N out of range (0x10...0x20)");
+        EXCEPTION_ASSERT_WITH_LOG(eccN >= 0x10 && eccN <= 0x20,
+            LibLogicalAccessException, sam::errorMessage(__func__, "ECC_N out of range (0x10...0x20)."));
 
-        if (eccM < 0x10 || eccM > 0x20)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                "PKI_ImportEccCurve : ECC_M out of range (0x10...0x20)");
+        EXCEPTION_ASSERT_WITH_LOG(eccM >= 0x10 && eccM <= 0x20,
+            LibLogicalAccessException, sam::errorMessage(__func__, "ECC_M out of range (0x10...0x20)."));
 
         const size_t expectedSize = 2 + (5 * static_cast<size_t>(eccN)) + static_cast<size_t>(eccM);
 
-        if (eccCurve.size() != expectedSize)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportEccCurve : ECC curve length mismatch");
+        EXCEPTION_ASSERT_WITH_LOG(eccCurve.size() == expectedSize,
+            LibLogicalAccessException, sam::errorMessage(__func__, "ECC curve length mismatch."));
 
         size_t offset = 2;
 
-        auto checkBlock = [&](size_t len, const char *name)
+        const auto checkBlock = [&](size_t length, const char *name)
         {
-            if (offset + len > eccCurve.size())
-                THROW_EXCEPTION_WITH_LOG(
-                    LibLogicalAccessException,
-                    std::string("PKI_ImportEccCurve: truncated field ") + name);
-            offset += len;
+            EXCEPTION_ASSERT_WITH_LOG(offset + length <= eccCurve.size(),
+                LibLogicalAccessException, sam::errorMessage(__func__, std::string("Truncated field ") + name + "."));
+            offset += length;
         };
 
         checkBlock(eccN, "ECC_Prime");
@@ -2361,65 +2037,35 @@ void SAMAV2ISO7816Commands::PKI_ImportEccCurve(unsigned char curveNo, unsigned c
         payload.insert(payload.end(), eccCurve.begin(), eccCurve.end());
     }
 
-    if (payload.size() > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ImportEccCurve : APDU too large (Lc overflow)");
+    EXCEPTION_ASSERT_WITH_LOG(payload.size() <= sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC,
+        LibLogicalAccessException, sam::errorMessage(__func__, "APDU payload too large."));
+
+    const unsigned char lc = static_cast<unsigned char>(payload.size());
 
     ByteVector apdu;
     apdu.reserve(5 + payload.size());
     apdu.push_back(d_cla);
-    apdu.push_back(0x22);
+    apdu.push_back(sam::ins::pki::ImportECCCurve);
     apdu.push_back(p1);
     apdu.push_back(0x00);
-    apdu.push_back(static_cast<unsigned char>(payload.size()));
+    apdu.push_back(lc);
     apdu.insert(apdu.end(), payload.begin(), payload.end());
 
     const ByteVector response = transmit(apdu, true, true);
-
-    if (response.size() < 2)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ImportEccCurve : response too short");
-
-    const uint16_t sw = sam::parseStatusWord(response);
-
-    if (sw == 0x9000)
-        return;
-
-    if (sw == 0x6A80)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ImportEccCurve: invalid curve number");
-
-    THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                             "PKI_ImportEccCurve: unexpected status word");
+    validateSuccessResponse(response, __func__);
 }
 
 ByteVector SAMAV2ISO7816Commands::PKI_ExportEccPublicKey(unsigned char keyNo)
 {
-    if (keyNo > 0x07)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-            "PKI_ExportEccPublicKey : keyNo out of range (0x00...0x07)");
+    EXCEPTION_ASSERT_WITH_LOG(keyNo <= 0x07,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Key number out of range (0x00...0x07)."));
 
-    ByteVector apdu;
-    apdu.reserve(5);
-    apdu.push_back(d_cla);
-    apdu.push_back(0x23);
-    apdu.push_back(keyNo);
-    apdu.push_back(0x00);
-    apdu.push_back(0x00);
+    ByteVector apdu{d_cla, sam::ins::pki::ExportECCPublicKey, keyNo, 0x00, 0x00};
 
     ByteVector response = transmit(apdu, true, true);
+    validateSuccessResponse(response, __func__);
 
-    if (response.size() < 2)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ExportEccPublicKey : response too short");
-
-    const uint16_t sw = sam::parseStatusWord(response);
-
-    if (sam::parseStatusWord(response) != 0x9000)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ExportEccPublicKey: unexpected status word");
-
-    response.resize(response.size() - 2);
+    response.resize(response.size() - sam::STATUS_WORD_SIZE);
     return response;
 }
 
@@ -2428,21 +2074,20 @@ void SAMAV2ISO7816Commands::PKI_VerifyEccSignature(unsigned char keyNo,
                                                    const ByteVector &message,
                                                    const ByteVector &signature)
 {
-    if (keyNo > 0x07)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-            "PKI_VerifyEccSignature : keyNo out of range (0x00...0x07)");
-    if (curveNo > 0x03)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-            "PKI_VerifyEccSignature : curveNo out of range (0x00...0x03)");
-    if (message.empty())
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_VerifyEccSignature : message cannot be empty");
-    if (message.size() > 0xFF)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_VerifyEccSignature : message too large");
-    if (signature.empty())
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_VerifyEccSignature : signature cannot be empty");
+    EXCEPTION_ASSERT_WITH_LOG(keyNo <= 0x07,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Key number out of range (0x00...0x07)."));
+
+    EXCEPTION_ASSERT_WITH_LOG(curveNo <= 0x03,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Curve number out of range (0x00...0x03)."));
+
+    EXCEPTION_ASSERT_WITH_LOG(!message.empty(),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Message cannot be empty."));
+
+    EXCEPTION_ASSERT_WITH_LOG(message.size() <= 0xFF,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Message too large."));
+
+    EXCEPTION_ASSERT_WITH_LOG(!signature.empty(),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Signature cannot be empty."));
 
     ByteVector payload;
     payload.reserve(3 + message.size() + signature.size());
@@ -2452,36 +2097,22 @@ void SAMAV2ISO7816Commands::PKI_VerifyEccSignature(unsigned char keyNo,
     payload.insert(payload.end(), message.begin(), message.end());
     payload.insert(payload.end(), signature.begin(), signature.end());
 
-    if (payload.size() > sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_VerifyEccSignature : APDU too large (Lc overflow)");
+    EXCEPTION_ASSERT_WITH_LOG(payload.size() <= sam::SAM_SECURE_CHANNEL_MAX_PLAIN_LC,
+        LibLogicalAccessException, sam::errorMessage(__func__, "APDU payload too large."));
+
+    const unsigned char lc = static_cast<unsigned char>(payload.size());
 
     ByteVector apdu;
     apdu.reserve(5 + payload.size());
     apdu.push_back(d_cla);
-    apdu.push_back(0x20);
+    apdu.push_back(sam::ins::pki::VerifyECCSignature);
     apdu.push_back(0x00);
     apdu.push_back(0x00);
-    apdu.push_back(static_cast<unsigned char>(payload.size()));
+    apdu.push_back(lc);
     apdu.insert(apdu.end(), payload.begin(), payload.end());
 
     const ByteVector response = transmit(apdu, true, true);
-
-    if (response.size() < 2)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_VerifyEccSignature : response too short");
-
-    const uint16_t sw = sam::parseStatusWord(response);
-
-    if (sw == 0x9000)
-        return;
-
-    if (sw == 0x6A80)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_VerifyEccSignature : invalid curve number");
-
-    THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                             "PKI_VerifyEccSignature : unexpected status word");
+    validateSuccessResponse(response, __func__);
 }
 
 }

--- a/plugins/logicalaccess/plugins/readers/iso7816/commands/samav2iso7816commands.cpp
+++ b/plugins/logicalaccess/plugins/readers/iso7816/commands/samav2iso7816commands.cpp
@@ -255,9 +255,6 @@ void SAMAV2ISO7816Commands::authenticateHost(std::shared_ptr<DESFireKey> key,
     ByteVector rnd1(RND_SIZE);
     EXCEPTION_ASSERT_WITH_LOG(RAND_bytes(rnd1.data(), static_cast<int>(rnd1.size())) == 1,
         LibLogicalAccessException, sam::errorMessage(__func__, "Cannot retrieve cryptographically strong bytes."));
-    /*if (RAND_bytes(&rnd1[0], static_cast<int>(rnd1.size())) != 1)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 sam::errorMessage(__func__, "Cannot retrieve cryptographically strong bytes"));*/
 
     ByteVector data_p2;
     data_p2.reserve(sam::MAC_SIZE + rnd1.size());
@@ -282,9 +279,6 @@ void SAMAV2ISO7816Commands::authenticateHost(std::shared_ptr<DESFireKey> key,
     ByteVector rndA(sam::AES_BLOCK_SIZE);
     EXCEPTION_ASSERT_WITH_LOG(RAND_bytes(rndA.data(), static_cast<int>(rndA.size())) == 1,
         LibLogicalAccessException, sam::errorMessage(__func__, "Cannot retrieve cryptographically strong bytes."));
-    /*if (RAND_bytes(&rndA[0], static_cast<int>(rndA.size())) != 1)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 sam::errorMessage(__func__, "Cannot retrieve cryptographically strong bytes"));*/
 
     // decipher rndB
     auto symkey = openssl::AESSymmetricKey::createFromData(d_authKey);
@@ -594,12 +588,7 @@ ByteVector SAMAV2ISO7816Commands::transmit(ByteVector cmd, bool first, bool last
     if (d_sessionKey.empty())
         return getISO7816ReaderCardAdapter()->sendCommand(cmd);
 
-    TransmissionOptions options;
-    options.protectRequest        = first || !s_mode;
-    options.processResponse       = last || !s_mode;
-    options.resetIvBeforeResponse = first;
-    options.resetIvAfterResponse  = last;
-    options.advanceCommandCounter = first || s_mode;
+    TransmissionOptions options {first || !s_mode, last || !s_mode, first, last, first || s_mode};
     return executeProtectedExchange(cmd, sam::ApduFormat::Standard, sam::PKI_ECC_LAYOUT, options);
 }
 

--- a/plugins/logicalaccess/plugins/readers/iso7816/commands/samav2iso7816commands.hpp
+++ b/plugins/logicalaccess/plugins/readers/iso7816/commands/samav2iso7816commands.hpp
@@ -179,11 +179,24 @@ class LLA_READERS_ISO7816_API SAMAV2ISO7816Commands
   protected:
     struct TransmissionOptions
     {
-        bool protectRequest        = true;
-        bool processResponse       = true;
-        bool resetIvBeforeResponse = true;
-        bool resetIvAfterResponse  = true;
-        bool advanceCommandCounter = true;
+        bool protectRequest;
+        bool processResponse;
+        bool resetIvBeforeResponse;
+        bool resetIvAfterResponse;
+        bool advanceCommandCounter;
+
+        constexpr TransmissionOptions(
+            bool protectRequest = true,
+            bool processResponse = true,
+            bool resetIvBeforeResponse = true,
+            bool resetIvAfterResponse = true,
+            bool advanceCommandCounter = true) noexcept
+            : protectRequest(protectRequest),
+              processResponse(processResponse),
+              resetIvBeforeResponse(resetIvBeforeResponse),
+              resetIvAfterResponse(resetIvAfterResponse),
+              advanceCommandCounter(advanceCommandCounter)
+        {}
     };
 
     void generateSessionKey(ByteVector rnd1, ByteVector rnd2);
@@ -216,7 +229,7 @@ class LLA_READERS_ISO7816_API SAMAV2ISO7816Commands
     ByteVector buildPlaintext(uint16_t changeCtr, const std::vector<std::shared_ptr<SAMBasicKeyEntry>> &entries);
     ByteVector rsa_oaep_encrypt(EVP_PKEY *pubKey, const ByteVector &plaintext, const EVP_MD *md);
     ByteVector rsa_pss_sign(EVP_PKEY *privKey, const ByteVector &data, const EVP_MD *md);
-    const EVP_MD *SAMAV2ISO7816Commands::getHash(sam::HashAlgo hashAlgo);
+    const EVP_MD *getHash(sam::HashAlgo hashAlgo);
     void buildCryptogram(EVP_PKEY *encKey, EVP_PKEY *signKey, uint8_t keyNoEnc, uint8_t keyNoSign, uint16_t changeCtr,
         const std::vector<std::shared_ptr<SAMBasicKeyEntry>> &entries,
         uint8_t hashAlgo, ByteVector &encFrame, ByteVector &signature);

--- a/plugins/logicalaccess/plugins/readers/iso7816/commands/samav2iso7816commands.hpp
+++ b/plugins/logicalaccess/plugins/readers/iso7816/commands/samav2iso7816commands.hpp
@@ -14,18 +14,13 @@
 #include <logicalaccess/plugins/readers/iso7816/iso7816readerunitconfiguration.hpp>
 #include <logicalaccess/plugins/cards/samav/samcrypto.hpp>
 #include <logicalaccess/plugins/cards/samav/samkeyentry.hpp>
-#include <logicalaccess/plugins/cards/samav/samcrypto.hpp>
 #include <logicalaccess/plugins/cards/samav/samav2commands.hpp>
 #include <string>
 #include <vector>
-#include <iostream>
 
 namespace logicalaccess
 {
 
-#define AV2_HEADER_LENGTH 0x05
-#define AV2_HEADER_LENGTH_WITH_LE 0x06
-#define AV2_LC_POS 0x04
 #define CMD_SAMAV2ISO7816 "SAMAV2ISO7816"
 
 #ifdef SWIG
@@ -58,10 +53,9 @@ class LLA_READERS_ISO7816_API SAMAV2ISO7816Commands
 
     void authenticateHost(std::shared_ptr<DESFireKey> key, unsigned char keyno) override;
 
-    void authenticateHost(std::shared_ptr<DESFireKey> key, unsigned char keyno, sam::HostMode hostmode);
+    void authenticateHost(const std::shared_ptr<DESFireKey> &key, unsigned char keyno, sam::HostMode hostmode);
 
-    std::shared_ptr<SAMKeyEntry<KeyEntryAV2Information, SETAV2>>
-    getKeyEntry(unsigned char keyno) override;
+    std::shared_ptr<SAMKeyEntry<KeyEntryAV2Information, SETAV2>> getKeyEntry(unsigned char keyno) override;
     std::shared_ptr<SAMKucEntry> getKUCEntry(unsigned char kucno) override;
 
     void changeKUCEntry(unsigned char kucno, std::shared_ptr<SAMKucEntry> kucEntry,
@@ -72,7 +66,7 @@ class LLA_READERS_ISO7816_API SAMAV2ISO7816Commands
 
     ByteVector transmit(ByteVector cmd, bool first = true, bool last = true, bool s_mode = false) override;
 
-    ByteVector dumpSecretKey(unsigned char keyno, unsigned char keyversion, const ByteVector& divInput) override;
+    ByteVector dumpSecretKey(unsigned char keyno, unsigned char keyversion, const ByteVector &divInput) override;
 
     void activateOfflineKey(unsigned char keyno, unsigned char keyversion, const ByteVector &divInput) override;
 
@@ -80,13 +74,13 @@ class LLA_READERS_ISO7816_API SAMAV2ISO7816Commands
 
     ByteVector encipherOfflineData(const ByteVector &data) override;
 	
-	void changeKeyEntryOffline(unsigned char keyno, const KeyEntryUpdateSettings& updateSettings,
-        unsigned short changecnt, const ByteVector& encke) override;
+	void changeKeyEntryOffline(unsigned char keyno, const KeyEntryUpdateSettings &updateSettings,
+        unsigned short changecnt, const ByteVector &encke) override;
 	
-	void changeKUCEntryOffline(unsigned char kucno, const KucEntryUpdateSettings& updateSettings,
-        unsigned short changecnt, const ByteVector& enckuc) override;
+	void changeKUCEntryOffline(unsigned char kucno, const KucEntryUpdateSettings &updateSettings,
+        unsigned short changecnt, const ByteVector &enckuc) override;
 	
-	void disableKeyEntryOffline(unsigned char keyno, unsigned short changecnt, const ByteVector& encuid) override;
+	void disableKeyEntryOffline(unsigned char keyno, unsigned short changecnt, const ByteVector &encuid) override;
 
     virtual ByteVector cmacOffline(const ByteVector &data);
 
@@ -100,13 +94,13 @@ class LLA_READERS_ISO7816_API SAMAV2ISO7816Commands
         return SAMISO7816Commands<KeyEntryAV2Information, SETAV2>::getReaderCardAdapter();
     }
 
-    void generateOfflineSessionKey(std::shared_ptr<DESFireKey> key, unsigned short changecnt);
+    void generateOfflineSessionKey(const std::shared_ptr<DESFireKey> &key, unsigned short changecnt);
 
     
     void PKI_GenerateKeyPair(unsigned char keyNo, unsigned short configSettings,
                              unsigned char keyNoCEK, unsigned char keyNoVCEK,
                              unsigned char keyNoRef, const sam::AEKVAEK &accessKeys,
-                             unsigned short nLen = 0x40,
+                             unsigned short nLen = 0x40, unsigned short eLen = 0x04,
                              const ByteVector &pki_e = {},
                              bool includeAccess = false) override;
 
@@ -123,11 +117,10 @@ class LLA_READERS_ISO7816_API SAMAV2ISO7816Commands
 
     ByteVector PKI_ExportPublicKey(unsigned char keyNo, bool returnAEK = false) override;
 
-    ByteVector
-    PKI_UpdateKeyEntries(EVP_PKEY &encKey, EVP_PKEY &signKey, unsigned char keyNoEnc,
-                         unsigned char keyNoSign, bool requestAck, unsigned char keyNoAck,
+    ByteVector PKI_UpdateKeyEntries(const ByteVector &encPublicKeyDer, const ByteVector &signPrivateKeyDer,
+                         unsigned char keyNoEnc, unsigned char keyNoSign, bool requestAck, unsigned char keyNoAck,
                          unsigned char hashAlgo, const std::vector<std::shared_ptr<SAMBasicKeyEntry>> &entries,
-                         uint16_t changeCounter) override;
+                         std::uint16_t changeCounter) override;
 
     ByteVector PKI_UpdateKeyEntries(unsigned char keyNoEnc, unsigned char keyNoSign,
                                     bool requestAck, unsigned char keyNoAck,
@@ -199,7 +192,12 @@ class LLA_READERS_ISO7816_API SAMAV2ISO7816Commands
         {}
     };
 
-    void generateSessionKey(ByteVector rnd1, ByteVector rnd2);
+    void generateSessionKey(const ByteVector &rnda, const ByteVector &rndb);
+    void deriveSessionKeys(const ByteVector &masterKey, const ByteVector &SV1a,
+                           const ByteVector &SV1b, const ByteVector &SV2a,
+                           const ByteVector &SV2b);
+    void mergeDerivedKeys(const ByteVector &sessionKeyExtension,
+                          const ByteVector &macSessionKeyExtension, std::size_t keySize);
 
     sam::ProtectedApdu prepareProtectedApdu(const ByteVector &cmd, sam::ApduFormat format = sam::ApduFormat::Standard);
 
@@ -226,16 +224,16 @@ class LLA_READERS_ISO7816_API SAMAV2ISO7816Commands
 
     ByteVector generateEncIV(bool encrypt) const;
 
-    ByteVector buildPlaintext(uint16_t changeCtr, const std::vector<std::shared_ptr<SAMBasicKeyEntry>> &entries);
+    ByteVector buildPlaintext(std::uint16_t changeCtr, const std::vector<std::shared_ptr<SAMBasicKeyEntry>> &entries);
     ByteVector rsa_oaep_encrypt(EVP_PKEY *pubKey, const ByteVector &plaintext, const EVP_MD *md);
     ByteVector rsa_pss_sign(EVP_PKEY *privKey, const ByteVector &data, const EVP_MD *md);
     const EVP_MD *getHash(sam::HashAlgo hashAlgo);
-    void buildCryptogram(EVP_PKEY *encKey, EVP_PKEY *signKey, uint8_t keyNoEnc, uint8_t keyNoSign, uint16_t changeCtr,
+    void buildCryptogram(EVP_PKEY *encKey, EVP_PKEY *signKey, std::uint8_t keyNoEnc, std::uint8_t keyNoSign, std::uint16_t changeCtr,
         const std::vector<std::shared_ptr<SAMBasicKeyEntry>> &entries,
-        uint8_t hashAlgo, ByteVector &encFrame, ByteVector &signature);
+        std::uint8_t hashAlgo, ByteVector &encFrame, ByteVector &signature);
 
     void resetIVs();
-    void secureZero(ByteVector &vec);
+    void secureZero(ByteVector &buffer) noexcept;
     void validateSuccessResponse(const ByteVector &response, const char *caller) const;
 
     ByteVector d_macSessionKey;

--- a/plugins/logicalaccess/plugins/readers/iso7816/commands/samav2iso7816commands.hpp
+++ b/plugins/logicalaccess/plugins/readers/iso7816/commands/samav2iso7816commands.hpp
@@ -58,35 +58,33 @@ class LLA_READERS_ISO7816_API SAMAV2ISO7816Commands
 
     void authenticateHost(std::shared_ptr<DESFireKey> key, unsigned char keyno) override;
 
-    void authenticateHost(std::shared_ptr<DESFireKey> key, unsigned char keyno,
-                          sam::HostMode hostmode);
+    void authenticateHost(std::shared_ptr<DESFireKey> key, unsigned char keyno, sam::HostMode hostmode);
 
     std::shared_ptr<SAMKeyEntry<KeyEntryAV2Information, SETAV2>>
     getKeyEntry(unsigned char keyno) override;
     std::shared_ptr<SAMKucEntry> getKUCEntry(unsigned char kucno) override;
 
-    void changeKUCEntry(unsigned char kucno, std::shared_ptr<SAMKucEntry> kucentry,
+    void changeKUCEntry(unsigned char kucno, std::shared_ptr<SAMKucEntry> kucEntry,
                         std::shared_ptr<DESFireKey> key) override;
-    void
-    changeKeyEntry(unsigned char keyno,
-                   std::shared_ptr<SAMKeyEntry<KeyEntryAV2Information, SETAV2>> keyentry,
+
+    void changeKeyEntry(unsigned char keyno, std::shared_ptr<SAMKeyEntry<KeyEntryAV2Information, SETAV2>> keyentry,
                    std::shared_ptr<DESFireKey> key) override;
 
     ByteVector transmit(ByteVector cmd, bool first = true, bool last = true, bool s_mode = false) override;
 
-    ByteVector dumpSecretKey(unsigned char keyno, unsigned char keyversion,
-                             ByteVector divInput) override;
+    ByteVector dumpSecretKey(unsigned char keyno, unsigned char keyversion, const ByteVector& divInput) override;
 
-    void activateOfflineKey(unsigned char keyno, unsigned char keyversion,
-                            ByteVector divInput) override;
+    void activateOfflineKey(unsigned char keyno, unsigned char keyversion, const ByteVector &divInput) override;
 
-    ByteVector decipherOfflineData(ByteVector data) override;
+    ByteVector decipherOfflineData(const ByteVector &data) override;
 
-    ByteVector encipherOfflineData(ByteVector data) override;
+    ByteVector encipherOfflineData(const ByteVector &data) override;
 	
-	void changeKeyEntryOffline(unsigned char keyno, const KeyEntryUpdateSettings& updateSettings, unsigned short changecnt, const ByteVector& encke) override;
+	void changeKeyEntryOffline(unsigned char keyno, const KeyEntryUpdateSettings& updateSettings,
+        unsigned short changecnt, const ByteVector& encke) override;
 	
-	void changeKUCEntryOffline(unsigned char kucno, const KucEntryUpdateSettings& updateSettings, unsigned short changecnt, const ByteVector& enckuc) override;
+	void changeKUCEntryOffline(unsigned char kucno, const KucEntryUpdateSettings& updateSettings,
+        unsigned short changecnt, const ByteVector& enckuc) override;
 	
 	void disableKeyEntryOffline(unsigned char keyno, unsigned short changecnt, const ByteVector& encuid) override;
 
@@ -143,11 +141,9 @@ class LLA_READERS_ISO7816_API SAMAV2ISO7816Commands
         unsigned short persoCtr, const std::vector<std::pair<unsigned char, unsigned char>> &keyEntries,
         const ByteVector &divInput = {}) override;
 
-    ByteVector PKI_GenerateHash(unsigned char hashAlgo,
-                                const ByteVector &message) override;
+    ByteVector PKI_GenerateHash(unsigned char hashAlgo, const ByteVector &message) override;
 
-    void PKI_GenerateSignature(unsigned char hashAlgo, unsigned char keyNoSign,
-                               const ByteVector &hash) override;
+    void PKI_GenerateSignature(unsigned char hashAlgo, unsigned char keyNoSign, const ByteVector &hash) override;
 
     ByteVector PKI_SendSignature() override;
 
@@ -181,32 +177,39 @@ class LLA_READERS_ISO7816_API SAMAV2ISO7816Commands
 
 
   protected:
+    struct TransmissionOptions
+    {
+        bool protectRequest        = true;
+        bool processResponse       = true;
+        bool resetIvBeforeResponse = true;
+        bool resetIvAfterResponse  = true;
+        bool advanceCommandCounter = true;
+    };
+
     void generateSessionKey(ByteVector rnd1, ByteVector rnd2);
 
-    sam::ApduResult createfullProtectionCmd(const ByteVector &cmd, sam::ApduFormat format = sam::ApduFormat::Standard);
-    ByteVector createMacProtectionCmd(const ByteVector &cmd);
+    sam::ProtectedApdu prepareProtectedApdu(const ByteVector &cmd, sam::ApduFormat format = sam::ApduFormat::Standard);
 
-    ByteVector transmitSecureChained(const ByteVector &cmd, sam::ApduFormat format = sam::ApduFormat::Standard, const sam::ChainingLayout &layout = sam::PKI_ECC_LAYOUT);
+    ByteVector executeProtectedExchange(const ByteVector &cmd, sam::ApduFormat format = sam::ApduFormat::Standard,
+        const sam::ChainingLayout &layout = sam::PKI_ECC_LAYOUT, const TransmissionOptions &options = TransmissionOptions{});
     
-    ByteVector transmitSecureResponseChained(const ByteVector &cmd, const sam::ChainingLayout &layout = sam::PKI_ECC_LAYOUT);
+    ByteVector sendChainedFrames(const std::vector<ByteVector> &frames);
+    ByteVector completeSecureExchange(ByteVector response, const TransmissionOptions &options);
 
-    ByteVector sendChainedFrames(const std::vector<ByteVector> &frames, unsigned char ins);
-    ByteVector receiveChainedResponse(unsigned char ins, ByteVector response,
-                                      unsigned char sw1, unsigned char sw2);
-    ByteVector finalizeSecureResponse(ByteVector response);
-
-    ByteVector sendChainedRespApdu(const ByteVector &cmd, const ByteVector &encData, const ByteVector &mac, const sam::ChainingLayout &layout = sam::PKI_ECC_LAYOUT, bool le = false);
-
-    std::vector<ByteVector> createChainedApduFrames(const ByteVector &cmd,
-                                                    const ByteVector &encData,
-                                                    const ByteVector &mac,
-                                                    const sam::ChainingLayout &layout = sam::PKI_ECC_LAYOUT,
-                                                    bool le = false);
+    std::vector<ByteVector> createApduFrames(const ByteVector &cmd, const sam::ProtectedApdu &protection,
+                                                    sam::ApduFormat format, const sam::ChainingLayout &layout);
+    std::vector<ByteVector> createSecureChainedApduFrames(const ByteVector &cmd, const sam::ProtectedApdu &protection,
+                                                    sam::ApduFormat format, const sam::ChainingLayout &layout);
+    std::vector<ByteVector> createPlainChainedApduFrames(const ByteVector &cmd, sam::ApduFormat format,
+        const sam::ChainingLayout &layout);
 
     ByteVector verifyAndDecryptResponse(const ByteVector &response);
-    ByteVector verifyAndDecryptMacResponse(const ByteVector &response);
 
+    ByteVector computeCommandMac(ByteVector &protectedCmd);
+    ByteVector encryptCommandData(const ByteVector &data);
     static void getLcLe(const ByteVector &cmd, bool &lc, bool &le);
+    sam::ApduInfo getApduInfo(const ByteVector &cmd, sam::ApduFormat format);
+    sam::ProtectedApdu prepareProtectedCommand(const ByteVector &cmd, sam::ApduFormat format);
 
     ByteVector generateEncIV(bool encrypt) const;
 
@@ -220,12 +223,15 @@ class LLA_READERS_ISO7816_API SAMAV2ISO7816Commands
 
     void resetIVs();
     void secureZero(ByteVector &vec);
+    void validateSuccessResponse(const ByteVector &response, const char *caller) const;
 
     ByteVector d_macSessionKey;
 
     ByteVector d_lastMacIV;
 
     unsigned int d_cmdCtr;
+
+    sam::HostMode d_hostMode{sam::HostMode::None};
 };
 }
 

--- a/plugins/logicalaccess/plugins/readers/iso7816/commands/samav3iso7816commands.cpp
+++ b/plugins/logicalaccess/plugins/readers/iso7816/commands/samav3iso7816commands.cpp
@@ -26,16 +26,16 @@ ByteVector SAMAV3ISO7816Commands::encipherKeyEntry(
 {
     unsigned char p2 = 0x00;
     ByteVector data;
+    data.reserve(4 + targetSamUid.size() + divInput.size());
     data.push_back(static_cast<unsigned char>(0x80 | (channel & 0x03)));
     data.push_back(targetKeyno);
-    data.push_back(static_cast<unsigned char>(0xff & (changeCounter >> 8)));
-    data.push_back(static_cast<unsigned char>(0xff & changeCounter));
-    if (targetSamUid.size() > 0)
+    sam::appendUInt16BE(data, changeCounter);
+    if (!targetSamUid.empty())
     {
         p2 |= 0x01;
         data.insert(data.end(), targetSamUid.begin(), targetSamUid.end());
     }
-    if (divInput.size() > 0)
+    if (!divInput.empty())
     {
         p2 |= 0x02;
         data.insert(data.end(), divInput.begin(), divInput.end());
@@ -45,695 +45,436 @@ ByteVector SAMAV3ISO7816Commands::encipherKeyEntry(
     return result.getData();
 }
 
-void SAMAV3ISO7816Commands::PKI_ImportCaPk(
-    const ByteVector &rid, unsigned char pkId, unsigned short set, unsigned char keyNoCEK,
-    unsigned char keyVCEK, unsigned char keyNoAEK, unsigned char keyVAEK,
-    unsigned char pkExpLen, const ByteVector &pk, const ByteVector &checkSum,
-    bool settingsOnly)
+void SAMAV3ISO7816Commands::PKI_ImportCaPk(const ByteVector &rid, unsigned char pkId, unsigned short set,
+                                           unsigned char keyNoCEK, unsigned char keyVCEK,
+                                           unsigned char keyNoAEK, unsigned char keyVAEK,
+                                           unsigned char pkExpLen, const ByteVector &pk,
+                                           const ByteVector &checkSum, bool settingsOnly)
 {
+    constexpr std::uint16_t SW_UNKNOWN_PK_INDEX = 0x6A83;
+    constexpr std::size_t RID_SIZE              = 5;
+    constexpr std::size_t CHECKSUM_SIZE         = 20;
+    constexpr std::size_t BASE_PAYLOAD_SIZE     = 12;
+    constexpr std::size_t FIXED_CRYPTO_SIZE     = 24;
+    constexpr std::size_t MIN_RSA_MODULUS_SIZE  = 0x40;
+    constexpr std::size_t MAX_RSA_MODULUS_SIZE  = 0xF8;
+    constexpr unsigned char EXPONENT_SHORT_SIZE = 1;
+    constexpr unsigned char EXPONENT_LONG_SIZE  = 3;
+    constexpr unsigned char ALGO_HASH           = 0x01;
+    constexpr unsigned char ALGO_PK             = 0x01;
 
-    if (rid.size() != 5)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ImportCaPk : RID must be exactly 5 bytes");
+    EXCEPTION_ASSERT_WITH_LOG(rid.size() == RID_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "RID must be exactly 5 bytes."));
 
-    if (settingsOnly && (!pk.empty() || !checkSum.empty()))
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ImportCaPk : crypto parameters must not be provided when settingsOnly = true");
+    EXCEPTION_ASSERT_WITH_LOG(!settingsOnly || (pk.empty() && checkSum.empty()), LibLogicalAccessException,
+        sam::errorMessage(__func__, "Crypto parameters must not be provided when settingsOnly = true."));
 
     if (!settingsOnly)
     {
-        if (pk.empty() || pk.size() < 0x40 || pk.size() > 0xF8)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportCaPk : invalid modulus size");
+        EXCEPTION_ASSERT_WITH_LOG(!pk.empty() && pk.size() >= MIN_RSA_MODULUS_SIZE && pk.size() <= MAX_RSA_MODULUS_SIZE,
+            LibLogicalAccessException, sam::errorMessage(__func__, "Invalid CA public key modulus length."));
 
-        if (pkExpLen != 0x01 && pkExpLen != 0x03)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportCaPk : invalid exponent length");
+        EXCEPTION_ASSERT_WITH_LOG(pkExpLen == EXPONENT_SHORT_SIZE || pkExpLen == EXPONENT_LONG_SIZE,
+            LibLogicalAccessException, sam::errorMessage(__func__, "Invalid public exponent length."));
 
-        if (checkSum.size() != 20)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportCaPk : checksum must be 20 bytes");
+        EXCEPTION_ASSERT_WITH_LOG(checkSum.size() == CHECKSUM_SIZE,
+            LibLogicalAccessException, sam::errorMessage(__func__, "Checksum must be exactly 20 bytes."));
     }
 
     ByteVector payload;
+    payload.reserve(settingsOnly ? BASE_PAYLOAD_SIZE : BASE_PAYLOAD_SIZE + FIXED_CRYPTO_SIZE + pk.size() + pkExpLen);
     payload.insert(payload.end(), rid.begin(), rid.end());
     payload.push_back(pkId);
-    payload.push_back((set >> 8) & 0xFF);
-    payload.push_back(set & 0xFF);
+    sam::appendUInt16BE(payload, set);
     payload.push_back(keyNoCEK);
     payload.push_back(keyVCEK);
     payload.push_back(keyNoAEK);
     payload.push_back(keyVAEK);
     if (!settingsOnly)
     {
-        payload.push_back(0x01);
-        payload.push_back(0x01);
+        payload.push_back(ALGO_HASH);
+        payload.push_back(ALGO_PK);
         payload.push_back(static_cast<unsigned char>(pk.size()));
         payload.insert(payload.end(), pk.begin(), pk.end());
         payload.push_back(pkExpLen);
-        if (pkExpLen == 0x01)
+        if (pkExpLen == EXPONENT_SHORT_SIZE)
             payload.push_back(0x03);
         else
             payload.insert(payload.end(), {0x01, 0x00, 0x01});
         payload.insert(payload.end(), checkSum.begin(), checkSum.end());
     }
 
-    size_t offset = 0;
-    const bool useSM = !d_sessionKey.empty();
+    const bool settingsPayload = payload.size() == BASE_PAYLOAD_SIZE;
+    const std::size_t MIN_PAYLOAD_SIZE = BASE_PAYLOAD_SIZE + 5 + MIN_RSA_MODULUS_SIZE + CHECKSUM_SIZE;
+    const std::size_t MAX_PAYLOAD_SIZE = BASE_PAYLOAD_SIZE + 7 + MAX_RSA_MODULUS_SIZE + CHECKSUM_SIZE;
+    const bool keyPayload = !settingsOnly && payload.size() >= MIN_PAYLOAD_SIZE && payload.size() <= MAX_PAYLOAD_SIZE;
 
-    auto buildAPDU = [&](unsigned char p1, const ByteVector &data, bool first,
-                         bool last) -> ByteVector
-    {
-        ByteVector apdu;
-        apdu.reserve(5 + data.size() + 1);
-        apdu.push_back(d_cla);
-        apdu.push_back(sam::ins::emv::ImportCaPk);
-        apdu.push_back(p1);
-        apdu.push_back(settingsOnly ? 0x80 : 0x00);
-        apdu.push_back(static_cast<unsigned char>(data.size()));
-        apdu.insert(apdu.end(), data.begin(), data.end());
-        return transmit(apdu, first, last, useSM);
-    };
+    EXCEPTION_ASSERT_WITH_LOG(settingsPayload || keyPayload,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Payload size does not match PKI Import CA PK format."));
 
-    while (offset < payload.size())
-    {
-        const size_t remaining = payload.size() - offset;
-        const size_t frameSize  = (std::min)(remaining, sam::MAX_APDU_DATA_SIZE);
-        const bool isFirstFrame = (offset == 0);
-        const bool isLastFrame  = (remaining <= sam::MAX_APDU_DATA_SIZE);
+    const unsigned char lc =
+        payload.size() > sam::MAX_SECURE_APDU_DATA_SIZE ? 0x00 : static_cast<unsigned char>(payload.size());
+    ByteVector apdu;
+    apdu.reserve(sam::APDU_HEADER_SIZE + payload.size());
+    apdu.push_back(d_cla);
+    apdu.push_back(sam::ins::emv::ImportCaPk);
+    apdu.push_back(0x00);
+    apdu.push_back(settingsOnly ? 0x80 : 0x00);
+    apdu.push_back(lc);
+    apdu.insert(apdu.end(), payload.begin(), payload.end());
 
-        ByteVector chunk(payload.begin() + offset, payload.begin() + offset + frameSize);
+    const ByteVector response = executeProtectedExchange(apdu, sam::ApduFormat::Extended, sam::EMV_LAYOUT);
 
-        const unsigned char p1 = isLastFrame ? 0x00 : 0xAF;
-        offset += frameSize;
+    if (sam::parseStatusWord(response) == SW_UNKNOWN_PK_INDEX)
+        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, sam::errorMessage(__func__, "Unknown PK index."));
 
-        const ByteVector result = buildAPDU(p1, chunk, isFirstFrame, isLastFrame);
-
-        if (result.size() < 2)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportCaPk : response too short");
-
-        const uint16_t sw = (result[result.size() - 2] << 8) | result[result.size() - 1];
-
-        if (sw == 0x9000)
-            return;
-
-        if (sw == 0x90AF)
-            continue;
-
-        if (sw == 0x6A80)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportCaPk : RID limit reached");
-
-        if (sw == 0x6A82)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportCaPk : unknown RID");
-
-        if (sw == 0x6A83)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportCaPk : unknown PK index");
-
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ImportCaPk : unexpected status word");
-    }
-    return;
+    validateSuccessResponse(response, __func__);
 }
 
 ByteVector SAMAV3ISO7816Commands::PKI_ImportCaPkOffline(const ByteVector &offlineCryptogram,
-                                             bool settingsOnly, bool requestAck)
+                                             bool settingsOnly, bool expectResponseData)
 {
-    if (offlineCryptogram.empty())
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ImportCaPkOffline : cryptogram empty");
+    EXCEPTION_ASSERT_WITH_LOG(!offlineCryptogram.empty(),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Offline cryptogram cannot be empty."));
 
-    const bool useSM = !d_sessionKey.empty();
+    constexpr std::size_t OFFLINE_CRYPTOGRAM_SHORT    = 26;
+    constexpr std::size_t OFFLINE_CRYPTOGRAM_MEDIUM   = 42;
+    constexpr std::size_t OFFLINE_CRYPTOGRAM_MIN_LONG = 122;
+    constexpr std::size_t OFFLINE_CRYPTOGRAM_MAX_LONG = 314;
+    constexpr std::size_t OFFLINE_ACK_SIZE            = 8;
 
-    auto buildAPDU = [&](unsigned char p1, const ByteVector &data, bool first,
-                         bool last) -> ByteVector
-    {
-        ByteVector apdu;
-        apdu.reserve(5 + data.size() + (requestAck ? 1 : 0));
-        apdu.push_back(d_cla);
-        apdu.push_back(sam::ins::emv::ImportCaPk);
-        apdu.push_back(p1);
-        apdu.push_back(settingsOnly ? 0x80 : 0x00);
-        apdu.push_back(static_cast<unsigned char>(data.size()));
-        apdu.insert(apdu.end(), data.begin(), data.end());
-        if (requestAck)
-            apdu.push_back(0x00);
-        return transmit(apdu, first, last, useSM);
-    };
+    const std::size_t cryptogramSize = offlineCryptogram.size();
+    const bool validCryptogramSize =
+        cryptogramSize == OFFLINE_CRYPTOGRAM_SHORT || cryptogramSize == OFFLINE_CRYPTOGRAM_MEDIUM ||
+        (cryptogramSize >= OFFLINE_CRYPTOGRAM_MIN_LONG && cryptogramSize <= OFFLINE_CRYPTOGRAM_MAX_LONG);
 
-    size_t offset = 0;
+    EXCEPTION_ASSERT_WITH_LOG(validCryptogramSize,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid offline cryptogram length."));
 
-    while (offset < offlineCryptogram.size())
-    {
-        const size_t remaining = offlineCryptogram.size() - offset;
-        const size_t frameSize = (std::min)(remaining, sam::MAX_APDU_DATA_SIZE);
-        const bool isFirstFrame = (offset == 0);
-        const bool isLastFrame  = (remaining <= sam::MAX_APDU_DATA_SIZE);
+    constexpr std::uint16_t SW_UNKNOWN_PK_INDEX    = 0x6A83;
+    constexpr std::uint8_t P2_IMPORT_SETTINGS_ONLY = 0x80;
+    constexpr std::uint8_t P2_IMPORT_FULL          = 0x00;
+    constexpr std::uint8_t LE_EXPECT_RESPONSE      = 0x00;
 
-        ByteVector chunk(offlineCryptogram.begin() + offset,
-                         offlineCryptogram.begin() + offset + frameSize);
+    const sam::ApduFormat type = expectResponseData ? sam::ApduFormat::ExtendedWithLe : sam::ApduFormat::Extended;
+    
+    const unsigned char lc = cryptogramSize > sam::MAX_SECURE_APDU_DATA_SIZE ?
+        0x00 : static_cast<unsigned char>(cryptogramSize);
+    ByteVector apdu;
+    apdu.reserve((expectResponseData ? sam::APDU_HEADER_WITH_LE_SIZE : sam::APDU_HEADER_SIZE) + cryptogramSize);
+    apdu.push_back(d_cla);
+    apdu.push_back(sam::ins::emv::ImportCaPk);
+    apdu.push_back(0x00);
+    apdu.push_back(settingsOnly ? P2_IMPORT_SETTINGS_ONLY : P2_IMPORT_FULL);
+    apdu.push_back(lc);
+    apdu.insert(apdu.end(), offlineCryptogram.begin(), offlineCryptogram.end());
+    if (expectResponseData)
+        apdu.push_back(LE_EXPECT_RESPONSE);
+    
+    const ByteVector response = executeProtectedExchange(apdu, type, sam::EMV_LAYOUT);
 
-        const unsigned char p1 = isLastFrame ? 0x00 : 0xAF;
+    if (sam::parseStatusWord(response) == SW_UNKNOWN_PK_INDEX)
+        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException, sam::errorMessage(__func__, "Unknown PK index."));
 
-        offset += frameSize;
+    validateSuccessResponse(response, __func__);
 
-        const ByteVector result = buildAPDU(p1, chunk, isFirstFrame, isLastFrame);
+    if (!expectResponseData)
+        return {};
 
-        if (result.size() < 2)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportCaPkOffline : response too short");
+    const ByteVector ack(response.begin(), response.end() - sam::STATUS_WORD_SIZE);
 
-        const uint16_t sw = (result[result.size() - 2] << 8) | result[result.size() - 1];
+    EXCEPTION_ASSERT_WITH_LOG(ack.size() == OFFLINE_ACK_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid offline acknowledgment length."));
 
-        const ByteVector data(result.begin(), result.end() - 2);
-
-        if (sw == 0x9000)
-            return requestAck ? data : ByteVector{};
-
-        if (sw == 0x90AF)
-            continue;
-
-        if (sw == 0x6A80)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportCaPkOffline : change counter error");
-
-        if (sw == 0x6A83)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ImportCaPkOffline : unknown PK index");
-
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ImportCaPkOffline : unexpected status word");
-    }
-
-    return ByteVector{};
+    return ack;
 }
 
-void SAMAV3ISO7816Commands::PKI_RemoveCaPk(const ByteVector &rid,
-                                                 unsigned char pkId)
+void SAMAV3ISO7816Commands::PKI_RemoveCaPk(const ByteVector &rid, unsigned char pkId)
 {
-    if (rid.size() != 5)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_RemoveCaPk : RID must be exactly 5 bytes");
+    constexpr std::size_t RID_SIZE     = 5;
+    constexpr std::size_t PAYLOAD_SIZE = RID_SIZE + 1;
 
-    const bool useSM = !d_sessionKey.empty();
+    EXCEPTION_ASSERT_WITH_LOG(rid.size() == RID_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "RID must be exactly 5 bytes."));
 
     ByteVector apdu;
-    apdu.reserve(5 + 6);
+    apdu.reserve(sam::APDU_HEADER_SIZE + PAYLOAD_SIZE);
     apdu.push_back(d_cla);
     apdu.push_back(sam::ins::emv::RemoveCaPk);
     apdu.push_back(0x00);
     apdu.push_back(0x00);
-    apdu.push_back(0x06);
+    apdu.push_back(static_cast<unsigned char>(PAYLOAD_SIZE));
     apdu.insert(apdu.end(), rid.begin(), rid.end());
     apdu.push_back(pkId);
 
-    const ByteVector result = transmit(apdu, true, true, useSM);
-
-    if (result.size() < 2)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_RemoveCaPk : response too short");
-
-    const uint16_t sw = (result[result.size() - 2] << 8) | result[result.size() - 1];
-
-    if (sw == 0x9000)
-        return;
-
-    if (sw == 0x6A80)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_RemoveCaPk : invalid RID");
-
-    THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                             "PKI_RemoveCaPk : unexpected status word");
+    const ByteVector response = executeProtectedExchange(apdu, sam::ApduFormat::Standard, sam::EMV_LAYOUT);
+    validateSuccessResponse(response, __func__);
 }
 
-ByteVector SAMAV3ISO7816Commands::PKI_RemoveCaPkOffline(const ByteVector &offlineCryptogram,
-                                             bool requestAck)
+ByteVector SAMAV3ISO7816Commands::PKI_RemoveCaPkOffline(const ByteVector &offlineCryptogram, bool expectResponseData)
 {
-    if (offlineCryptogram.size() != 26)
-        THROW_EXCEPTION_WITH_LOG(
-            LibLogicalAccessException,
-            "PKI_RemoveCaPkOffline : OfflineCryptogram must be 26 bytes");
-    const bool useSM = !d_sessionKey.empty();
+    constexpr std::size_t OFFLINE_CRYPTOGRAM_SIZE = 0x1A;
+    constexpr std::size_t OFFLINE_ACK_SIZE        = 8;
+    constexpr std::uint8_t LE_EXPECT_RESPONSE     = 0x00;
+
+    EXCEPTION_ASSERT_WITH_LOG(offlineCryptogram.size() == OFFLINE_CRYPTOGRAM_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Offline cryptogram must be exactly 26 bytes."));
 
     ByteVector apdu;
-    apdu.reserve(5 + offlineCryptogram.size() + (requestAck ? 1 : 0));
+    apdu.reserve((expectResponseData ? sam::APDU_HEADER_WITH_LE_SIZE : sam::APDU_HEADER_SIZE) + OFFLINE_CRYPTOGRAM_SIZE);
     apdu.push_back(d_cla);
     apdu.push_back(sam::ins::emv::RemoveCaPk);
     apdu.push_back(0x00);
     apdu.push_back(0x00);
-    apdu.push_back(0x1A);
+    apdu.push_back(static_cast<unsigned char>(OFFLINE_CRYPTOGRAM_SIZE));
     apdu.insert(apdu.end(), offlineCryptogram.begin(), offlineCryptogram.end());
-    if (requestAck)
-        apdu.push_back(0x00);
+    if (expectResponseData)
+        apdu.push_back(LE_EXPECT_RESPONSE);
 
-    const ByteVector result = transmit(apdu, true, true, useSM);
+    const ByteVector response = executeProtectedExchange(apdu, sam::ApduFormat::Standard, sam::EMV_LAYOUT);
 
-    if (result.size() < 2)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_RemoveCaPkOffline : response too short");
+    validateSuccessResponse(response, __func__);
 
-    const uint16_t sw = (result[result.size() - 2] << 8) | result[result.size() - 1];
-
-    const ByteVector data(result.begin(), result.end() - 2);
-
-    if (sw != 0x9000)
-    {
-        if (sw == 0x6A80)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_RemoveCaPkOffline: incorrect change counter");
-
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_RemoveCaPkOffline: unexpected status word");
-    }
-
-    if (!requestAck)
+    if (!expectResponseData)
         return {};
 
-    if (data.size() != 8)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_RemoveCaPkOffline : invalid OfflineAck size");
+    const ByteVector ack(response.begin(), response.end() - sam::STATUS_WORD_SIZE);
 
-    return data;
+    EXCEPTION_ASSERT_WITH_LOG(ack.size() == OFFLINE_ACK_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid offline acknowledgment length."));
+
+    return ack;
 }
 
-ByteVector SAMAV3ISO7816Commands::PKI_ExportCaPk(const ByteVector &rid,
-                                                 unsigned char pkId, bool settingsOnly)
+ByteVector SAMAV3ISO7816Commands::PKI_ExportCaPk(const ByteVector &rid, unsigned char pkId, bool settingsOnly)
 {
+    constexpr std::size_t RID_SIZE            = 5;
+    constexpr std::size_t PAYLOAD_SIZE        = RID_SIZE + 1;
+    constexpr std::uint8_t P1_SETTINGS_ONLY   = 0x80;
+    constexpr std::uint8_t P1_FULL            = 0x00;
+    constexpr std::uint8_t LE_EXPECT_RESPONSE = 0x00;
 
-    if (rid.size() != 5)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ExportCaPk : RID must be exactly 5 bytes");
+    EXCEPTION_ASSERT_WITH_LOG(rid.size() == RID_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "RID must be exactly 5 bytes."));
 
-    const bool useSM = !d_sessionKey.empty();
-    const unsigned char p1 = settingsOnly ? 0x80 : 0x00;
+    const unsigned char p1 = settingsOnly ? P1_SETTINGS_ONLY : P1_FULL;
 
-    ByteVector payload;
-    payload.reserve(rid.size() + 1);
-    payload.insert(payload.end(), rid.begin(), rid.end());
-    payload.push_back(pkId);
+    ByteVector apdu;
+    apdu.reserve(sam::APDU_HEADER_WITH_LE_SIZE + PAYLOAD_SIZE);
+    apdu.push_back(d_cla);
+    apdu.push_back(sam::ins::emv::ExportCaPk);
+    apdu.push_back(p1);
+    apdu.push_back(0x00);
+    apdu.push_back(static_cast<unsigned char>(PAYLOAD_SIZE));
+    apdu.insert(apdu.end(), rid.begin(), rid.end());
+    apdu.push_back(pkId);
+    apdu.push_back(LE_EXPECT_RESPONSE);
 
-    auto buildAPDU = [&](unsigned char p1, const ByteVector &data, bool first,
-                         bool last) -> ByteVector
-    {
-        ByteVector apdu;
-        apdu.reserve(5 + data.size() + 1);
-        apdu.push_back(d_cla);
-        apdu.push_back(sam::ins::emv::ExportCaPk);
-        apdu.push_back(p1);
-        apdu.push_back(0x00);
-        apdu.push_back(static_cast<unsigned char>(data.size()));
-        if (!data.empty())
-            apdu.insert(apdu.end(), data.begin(), data.end());
-        apdu.push_back(0x00);
-        return transmit(apdu, first, last, useSM);
-    };
-
-    ByteVector fullResponse;
-    bool firstFrame = true;
-    int frames = 0; //TODO : check if frames > 2
-
-    while (true)
-    {
-        const ByteVector data   = firstFrame ? payload : ByteVector{};
-        const bool isLast       = (frames == 1);
-        ByteVector result = buildAPDU(p1, data, firstFrame, isLast);
-        if (result.size() < 2)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ExportCaPk : response too short");
-
-        const uint16_t sw = (result[result.size() - 2] << 8) | result[result.size() - 1];
-        result.resize(result.size() - 2);
-
-        if (!result.empty())
-            fullResponse.insert(fullResponse.end(), result.begin(), result.end());
-
-        frames++;
-
-        if (sw == 0x9000)
-            return fullResponse;
-        else if (sw == 0x90AF)
-        {
-            /* if (frames >= 2)
-            {
-                THROW_EXCEPTION_WITH_LOG(
-                    LibLogicalAccessException,
-                    "PKI_ExportCaPk : more than 2 frames not supported");
-            }*/
-            firstFrame = false;
-            continue;
-        }
-        if (sw == 0x6986)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ExportCaPk : export not allowed");
-
-        if (sw == 0x6A80)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_ExportCaPk : invalid RID");
-
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_ExportCaPk : unexpected status word");
-    }
+    ByteVector response = executeProtectedExchange(apdu, sam::ApduFormat::Standard, sam::EMV_LAYOUT);
+    validateSuccessResponse(response, __func__);
+    response.resize(response.size() - sam::STATUS_WORD_SIZE);
+    return response;
 }
 
-ByteVector SAMAV3ISO7816Commands::PKI_LoadIssuerPk(
-    const ByteVector &rid, unsigned char pkId, const ByteVector &issuerPkCert,
-    const ByteVector &issuerPkRemainder, unsigned char pkExpLen)
+ByteVector SAMAV3ISO7816Commands::PKI_LoadIssuerPk(const ByteVector &rid, unsigned char pkId,
+                                                   const ByteVector &issuerPkCert, const ByteVector &issuerPkRemainder,
+                                                   unsigned char pkExpLen)
 {
-    if (rid.size() != 5)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_LoadIssuerPk : RID must be exactly 5 bytes");
+    constexpr std::size_t RID_SIZE              = 5;
+    constexpr std::size_t MAX_LENGTH_FIELD_SIZE = 0xFF;
+    constexpr unsigned char EXPONENT_SHORT_SIZE = 0x01;
+    constexpr unsigned char EXPONENT_LONG_SIZE  = 0x03;
+    constexpr std::uint8_t LE_EXPECT_RESPONSE   = 0x00;
+    constexpr std::size_t RESPONSE_SIZE         = 9;
 
-    if (issuerPkCert.empty())
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_LoadIssuerPk : issuerPkCert cannot be empty");
+    EXCEPTION_ASSERT_WITH_LOG(rid.size() == RID_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "RID must be exactly 5 bytes."));
 
-    if (pkExpLen != 0x01 && pkExpLen != 0x03)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_LoadIssuerPk : pkExpLen must be 0x01 or 0x03");
+    EXCEPTION_ASSERT_WITH_LOG(!issuerPkCert.empty(),
+        LibLogicalAccessException, sam::errorMessage(__func__, "Issuer public key certificate cannot be empty."));
 
-    const ByteVector pkExp =
-        (pkExpLen == 0x01) ? ByteVector{0x03} : ByteVector{0x01, 0x00, 0x01};
+    EXCEPTION_ASSERT_WITH_LOG(pkExpLen == EXPONENT_SHORT_SIZE || pkExpLen == EXPONENT_LONG_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid public exponent length."));
+
+    EXCEPTION_ASSERT_WITH_LOG(issuerPkCert.size() <= MAX_LENGTH_FIELD_SIZE &&
+        issuerPkRemainder.size() <= MAX_LENGTH_FIELD_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Issuer key component too large."));
+
+    const ByteVector pkExp = (pkExpLen == EXPONENT_SHORT_SIZE) ? ByteVector{0x03} : ByteVector{0x01, 0x00, 0x01};
 
     ByteVector payload;
+    payload.reserve(rid.size() + 1u + 1u + issuerPkCert.size() + 1u + issuerPkRemainder.size() + 1u + pkExpLen);
     payload.insert(payload.end(), rid.begin(), rid.end());
     payload.push_back(pkId);
     payload.push_back(static_cast<unsigned char>(issuerPkCert.size()));
     payload.insert(payload.end(), issuerPkCert.begin(), issuerPkCert.end());
     payload.push_back(static_cast<unsigned char>(issuerPkRemainder.size()));
     if (!issuerPkRemainder.empty())
-        payload.insert(payload.end(), issuerPkRemainder.begin(),
-                           issuerPkRemainder.end());
+        payload.insert(payload.end(), issuerPkRemainder.begin(), issuerPkRemainder.end());
     payload.push_back(pkExpLen);
     payload.insert(payload.end(), pkExp.begin(), pkExp.end());
 
-    ByteVector fullResponse;
-    size_t offset   = 0;
-    const bool useSM = !d_sessionKey.empty();
+    const unsigned char lc =
+        payload.size() > sam::MAX_SECURE_APDU_DATA_SIZE ? 0x00 : static_cast<unsigned char>(payload.size());
+    ByteVector apdu;
+    apdu.reserve(sam::APDU_HEADER_WITH_LE_SIZE + payload.size());
+    apdu.push_back(d_cla);
+    apdu.push_back(sam::ins::emv::LoadIssuerPk);
+    apdu.push_back(0x00);
+    apdu.push_back(0x00);
+    apdu.push_back(lc);
+    apdu.insert(apdu.end(), payload.begin(), payload.end());
+    apdu.push_back(LE_EXPECT_RESPONSE);
 
-    auto buildAPDU = [&](unsigned char p1, const ByteVector &data,
-                         bool first, bool last) -> ByteVector
-    {
-        ByteVector apdu;
-        apdu.reserve(5 + data.size() + 1);
-        apdu.push_back(d_cla);
-        apdu.push_back(sam::ins::emv::LoadIssuerPk);
-        apdu.push_back(p1);
-        apdu.push_back(0x00);
-        apdu.push_back(static_cast<uint8_t>(data.size()));
-        apdu.insert(apdu.end(), data.begin(), data.end());
-        apdu.push_back(0x00);
-        return transmit(apdu, first, last, useSM);
-    };
-
-    while (offset < payload.size())
-    {
-        const size_t remaining = payload.size() - offset;
-        const size_t frameSize  = (std::min)(remaining, sam::MAX_APDU_DATA_SIZE);
-        const bool isFirstFrame = (offset == 0);
-        const bool isLastFrame  = (remaining <= sam::MAX_APDU_DATA_SIZE);
-
-        ByteVector chunk(payload.begin() + offset, payload.begin() + offset + frameSize);
-
-        const unsigned char p1 = isLastFrame ? 0x00 : 0xAF;
-        offset += frameSize;
-
-        const ByteVector result = buildAPDU(p1, chunk, isFirstFrame, isLastFrame);
-
-        if (result.size() < 2)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_LoadIssuerPk : response too short");
-
-        const uint16_t sw = (result[result.size() - 2] << 8) | result[result.size() - 1];
-        fullResponse.insert(fullResponse.end(), result.begin(), result.end() - 2);
-
-        if (sw == 0x9000)
-            return fullResponse;
-
-        if (sw == 0x90AF)
-            continue;
-
-        if (sw == 0x6A80)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_LoadIssuerPk : invalid RID");
-
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_LoadIssuerPk : unexpected status word");
-    }
-
-    return fullResponse;
+    ByteVector response = executeProtectedExchange(apdu, sam::ApduFormat::ExtendedWithLe, sam::EMV_LAYOUT);
+    validateSuccessResponse(response, __func__);
+    response.resize(response.size() - sam::STATUS_WORD_SIZE);
+    EXCEPTION_ASSERT_WITH_LOG(response.size() == RESPONSE_SIZE,
+                              LibLogicalAccessException, sam::errorMessage(__func__, "Invalid response length."));
+    return response;
 }
 
-ByteVector SAMAV3ISO7816Commands::PKI_LoadIccPk(const ByteVector &iccPkCert,
-                                                const ByteVector &iccPkRemainder,
-                                                const ByteVector &staticData,
-                                                unsigned char pkExpLen)
+ByteVector SAMAV3ISO7816Commands::PKI_LoadIccPk(const ByteVector &iccPkCert, const ByteVector &iccPkRemainder,
+                                                const ByteVector &staticData, unsigned char pkExpLen)
 {
+    EXCEPTION_ASSERT_WITH_LOG(!iccPkCert.empty(),
+        LibLogicalAccessException, sam::errorMessage(__func__, "ICC public key certificate cannot be empty."));
 
-    if (iccPkCert.empty())
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_LoadIccPk : iccPkCert cannot be empty");
+    constexpr std::size_t MAX_LENGTH_FIELD_SIZE = 0xFF;
+    constexpr unsigned char EXPONENT_SHORT_SIZE = 0x01;
+    constexpr unsigned char EXPONENT_LONG_SIZE  = 0x03;
+    constexpr std::uint8_t LE_EXPECT_RESPONSE   = 0x00;
+    constexpr std::size_t RESPONSE_SIZE         = 16;
 
-    if (pkExpLen != 0x01 && pkExpLen != 0x03)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_LoadIccPk : pkExpLen must be 0x01 or 0x03");
+    EXCEPTION_ASSERT_WITH_LOG(pkExpLen == EXPONENT_SHORT_SIZE || pkExpLen == EXPONENT_LONG_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid public exponent length."));
 
-    const ByteVector pkExp =
-        (pkExpLen == 0x01) ? ByteVector{0x03} : ByteVector{0x01, 0x00, 0x01};
+    EXCEPTION_ASSERT_WITH_LOG(iccPkCert.size() <= MAX_LENGTH_FIELD_SIZE && iccPkRemainder.size() <= MAX_LENGTH_FIELD_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "ICC key component too large."));
+
+    const ByteVector pkExp = (pkExpLen == EXPONENT_SHORT_SIZE) ? ByteVector{0x03} : ByteVector{0x01, 0x00, 0x01};
 
     ByteVector payload;
-
+    payload.reserve(1u + iccPkCert.size() + 1u + iccPkRemainder.size() + 1u + pkExpLen + staticData.size());
     payload.push_back(static_cast<unsigned char>(iccPkCert.size()));
     payload.insert(payload.end(), iccPkCert.begin(), iccPkCert.end());
     payload.push_back(static_cast<unsigned char>(iccPkRemainder.size()));
     if (!iccPkRemainder.empty())
-        payload.insert(payload.end(), iccPkRemainder.begin(),
-                           iccPkRemainder.end());
+        payload.insert(payload.end(), iccPkRemainder.begin(), iccPkRemainder.end());
     payload.push_back(pkExpLen);
     payload.insert(payload.end(), pkExp.begin(), pkExp.end());
     if (!staticData.empty())
         payload.insert(payload.end(), staticData.begin(), staticData.end());
 
-    ByteVector fullResponse;
-    size_t offset   = 0;
-    const bool useSM = !d_sessionKey.empty();
+    const unsigned char lc =
+        payload.size() > sam::MAX_SECURE_APDU_DATA_SIZE ? 0x00 : static_cast<unsigned char>(payload.size());
+    ByteVector apdu;
+    apdu.reserve(sam::APDU_HEADER_WITH_LE_SIZE + payload.size());
+    apdu.push_back(d_cla);
+    apdu.push_back(sam::ins::emv::LoadIccPk);
+    apdu.push_back(0x00);
+    apdu.push_back(0x00);
+    apdu.push_back(lc);
+    apdu.insert(apdu.end(), payload.begin(), payload.end());
+    apdu.push_back(LE_EXPECT_RESPONSE);
 
-    auto buildAPDU  = [&](unsigned char p1, const ByteVector &data,
-                         bool first, bool last) -> ByteVector
-    {
-        ByteVector apdu;
-        apdu.reserve(5 + data.size() + 1);
-        apdu.push_back(d_cla);
-        apdu.push_back(sam::ins::emv::LoadIccPk);
-        apdu.push_back(p1);
-        apdu.push_back(0x00);
-        apdu.push_back(static_cast<unsigned char>(data.size()));
-        apdu.insert(apdu.end(), data.begin(), data.end());
-        apdu.push_back(0x00);
-        return transmit(apdu, first, last, useSM);
-    };
-
-    while (offset < payload.size())
-    {
-        const size_t remaining = payload.size() - offset;
-        const size_t frameSize = (std::min)(remaining, sam::MAX_APDU_DATA_SIZE);
-        const bool isFirstFrame = (offset == 0);
-        const bool isLastFrame = (remaining <= sam::MAX_APDU_DATA_SIZE);
-
-        ByteVector chunk(payload.begin() + offset, payload.begin() + offset + frameSize);
-
-        const unsigned char p1 = isLastFrame ? 0x00 : 0xAF;
-        offset += frameSize;
-
-        const ByteVector result = buildAPDU(p1, chunk, isFirstFrame, isLastFrame);
-
-        if (result.size() < 2)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_LoadIccPk : response too short");
-
-        const uint16_t sw = (result[result.size() - 2] << 8) | result[result.size() - 1];
-        fullResponse.insert(fullResponse.end(), result.begin(), result.end() - 2);
-
-        if (sw == 0x9000)
-            return fullResponse;
-
-        if (sw == 0x90AF)
-            continue;
-
-        if (sw == 0x6A80)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "PKI_LoadIccPk : missing required remainder");
-
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "PKI_LoadIccPk : unexpected status word");
-    }
-    return fullResponse;
+    ByteVector response = executeProtectedExchange(apdu, sam::ApduFormat::ExtendedWithLe, sam::EMV_LAYOUT);
+    validateSuccessResponse(response, __func__);
+    response.resize(response.size() - sam::STATUS_WORD_SIZE);
+    EXCEPTION_ASSERT_WITH_LOG(response.size() == RESPONSE_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid response length."));
+    return response;
 }
 
 ByteVector SAMAV3ISO7816Commands::SAM_RecoverStaticData(const ByteVector &ssad)
 {
-    if (d_sessionKey.empty())
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "SAM_RecoverStaticData : requires S-mode (no session key)");
-    if (ssad.empty())
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "SAM_RecoverStaticData : SSAD cannot be empty");
-    if (ssad.size() < 0x40)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "SAM_RecoverStaticData : SDAD too small");
+    constexpr std::size_t MIN_SSAD_SIZE       = 0x40;
+    constexpr std::uint8_t LE_EXPECT_RESPONSE = 0x00;
+    constexpr std::size_t RESPONSE_SIZE       = 23;
 
-    ByteVector fullResponse;
-    size_t offset = 0;
+    EXCEPTION_ASSERT_WITH_LOG(!ssad.empty(),
+        LibLogicalAccessException, sam::errorMessage(__func__, "SSAD cannot be empty."));
 
-    auto buildAPDU = [&](unsigned char p1, const ByteVector &data, bool first, bool last) -> ByteVector
-    {
-        ByteVector apdu;
-        apdu.reserve(5 + data.size() + 1);
-        apdu.push_back(d_cla);
-        apdu.push_back(sam::ins::emv::RecoverStaticData);
-        apdu.push_back(p1);
-        apdu.push_back(0x00);
-        apdu.push_back(static_cast<unsigned char>(data.size()));
-        apdu.insert(apdu.end(), data.begin(), data.end());
-        apdu.push_back(0x00);
-        return transmit(apdu, first, last, true);
-    };
+    EXCEPTION_ASSERT_WITH_LOG(ssad.size() >= MIN_SSAD_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "SSAD length is too small."));
 
-    while (offset < ssad.size())
-    {
-        const size_t remaining = ssad.size() - offset;
-        const size_t frameSize = (std::min)(remaining, sam::MAX_APDU_DATA_SIZE);
-        const bool isFirstFrame = (offset == 0);
-        const bool isLastFrame  = (remaining <= sam::MAX_APDU_DATA_SIZE);
+    const unsigned char lc =
+        ssad.size() > sam::MAX_SECURE_APDU_DATA_SIZE ? 0x00 : static_cast<unsigned char>(ssad.size());
+    ByteVector apdu;
+    apdu.reserve(sam::APDU_HEADER_WITH_LE_SIZE + ssad.size());
+    apdu.push_back(d_cla);
+    apdu.push_back(sam::ins::emv::RecoverStaticData);
+    apdu.push_back(0x00);
+    apdu.push_back(0x00);
+    apdu.push_back(lc);
+    apdu.insert(apdu.end(), ssad.begin(), ssad.end());
+    apdu.push_back(LE_EXPECT_RESPONSE);
 
-        ByteVector chunk(ssad.begin() + offset, ssad.begin() + offset + frameSize);
-
-        const unsigned char p1 = isLastFrame ? 0x00 : 0xAF;
-        offset += frameSize;
-
-        const ByteVector result = buildAPDU(p1, chunk, isFirstFrame, isLastFrame);
-
-        if (result.size() < 2)
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "SAM_RecoverStaticData : invalid response");
-
-        const uint16_t sw = (result[result.size() - 2] << 8) | result[result.size() - 1];
-
-        fullResponse.insert(fullResponse.end(), result.begin(), result.end() - 2);
-
-        if (sw == 0x9000)
-            return fullResponse;
-
-        if (sw == 0x90AF)
-            continue;
-
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "SAM_RecoverStaticData : unexpected status word");
-    }
-
-    return fullResponse;
+    ByteVector response = executeProtectedExchange(apdu, sam::ApduFormat::ExtendedWithLe, sam::EMV_LAYOUT);
+    validateSuccessResponse(response, __func__);
+    response.resize(response.size() - sam::STATUS_WORD_SIZE);
+    EXCEPTION_ASSERT_WITH_LOG(response.size() == RESPONSE_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "Invalid response length."));
+    return response;
 }
 
 ByteVector SAMAV3ISO7816Commands::SAM_RecoverDynamicData(const ByteVector &sdad)
 {
-    if (d_sessionKey.empty())
-        THROW_EXCEPTION_WITH_LOG(
-            LibLogicalAccessException,
-            "SAM_RecoverDynamicData : requires S-mode (no session key)");
-    if (sdad.empty())
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "SAM_RecoverDynamicData : SDAD cannot be empty");
-    if (sdad.size() < 0x40)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "SAM_RecoverDynamicData : SDAD too small");
+    constexpr std::size_t MIN_SDAD_SIZE       = 0x40;
+    constexpr std::uint8_t LE_EXPECT_RESPONSE = 0x00;
 
-    ByteVector fullResponse;
-    size_t offset = 0;
+    EXCEPTION_ASSERT_WITH_LOG(!sdad.empty(),
+        LibLogicalAccessException, sam::errorMessage(__func__, "SDAD must not be empty."));
 
-    auto buildAPDU = [&](unsigned char p1, const ByteVector &data,
-                         bool first, bool last) -> ByteVector
-    {
-        ByteVector apdu;
-        apdu.reserve(5 + data.size() + 1);
-        apdu.push_back(d_cla);
-        apdu.push_back(sam::ins::emv::RecoverDynamicData);
-        apdu.push_back(p1);
-        apdu.push_back(0x00);
-        apdu.push_back(static_cast<unsigned char>(data.size()));
-        apdu.insert(apdu.end(), data.begin(), data.end());
-        apdu.push_back(0x00);
-        return transmit(apdu, first, last, true);
-    };
+    EXCEPTION_ASSERT_WITH_LOG(sdad.size() >= MIN_SDAD_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "SDAD length is too small."));
 
-    while (offset < sdad.size())
-    {
-        const size_t remaining = sdad.size() - offset;
-        const size_t frameSize = (std::min)(remaining, sam::MAX_APDU_DATA_SIZE);
-        const bool isFirstFrame = (offset == 0);
-        const bool isLastFrame  = (remaining <= sam::MAX_APDU_DATA_SIZE);
+    const unsigned char lc =
+        sdad.size() > sam::MAX_SECURE_APDU_DATA_SIZE ? 0x00 : static_cast<unsigned char>(sdad.size());
+    ByteVector apdu;
+    apdu.reserve(sam::APDU_HEADER_WITH_LE_SIZE + sdad.size());
+    apdu.push_back(d_cla);
+    apdu.push_back(sam::ins::emv::RecoverDynamicData);
+    apdu.push_back(0x00);
+    apdu.push_back(0x00);
+    apdu.push_back(lc);
+    apdu.insert(apdu.end(), sdad.begin(), sdad.end());
+    apdu.push_back(LE_EXPECT_RESPONSE);
 
-        ByteVector chunk(sdad.begin() + offset, sdad.begin() + offset + frameSize);
-
-        const unsigned char p1 = isLastFrame ? 0x00 : 0xAF;
-        offset += frameSize;
-
-        const ByteVector result = buildAPDU(p1, chunk, isFirstFrame, isLastFrame);
-
-        if (result.size() < 2)
-        {
-            THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                     "SAM_RecoverDynamicData : response too short");
-        }
-
-        const uint16_t sw = (result[result.size() - 2] << 8) | result[result.size() - 1];
-
-        fullResponse.insert(fullResponse.end(), result.begin(), result.end() - 2);
-        
-        if (sw == 0x9000)
-            return fullResponse;
-        else if (sw == 0x90AF)
-            continue;
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "SAM_RecoverDynamicData : unexpected status word");
-    }
-    return fullResponse;
+    ByteVector response = executeProtectedExchange(apdu, sam::ApduFormat::ExtendedWithLe, sam::EMV_LAYOUT);
+    validateSuccessResponse(response, __func__);
+    response.resize(response.size() - sam::STATUS_WORD_SIZE);
+    return response;
 }
 
-ByteVector SAMAV3ISO7816Commands::SAM_EncipherPIN(const ByteVector &pinBlock,
-                                                  const ByteVector &iccNumber)
+ByteVector SAMAV3ISO7816Commands::SAM_EncipherPIN(const ByteVector &pinBlock, const ByteVector &iccNumber)
 {
-    if (d_sessionKey.empty())
-        THROW_EXCEPTION_WITH_LOG(
-            LibLogicalAccessException,
-            "SAM_EncipherPIN : requires S-mode (no session key)");
-    if (pinBlock.size() != 8)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "SAM_EncipherPIN : PIN block must be exactly 8 bytes");
-    if (iccNumber.size() != 8)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "SAM_EncipherPIN : ICC number must be exactly 8 bytes");
+    constexpr std::size_t PIN_BLOCK_SIZE      = 8;
+    constexpr std::size_t ICC_NUMBER_SIZE     = 8;
+    constexpr std::size_t PAYLOAD_SIZE        = PIN_BLOCK_SIZE + ICC_NUMBER_SIZE;
+    constexpr std::uint8_t LE_EXPECT_RESPONSE = 0x00;
+
+    EXCEPTION_ASSERT_WITH_LOG(pinBlock.size() == PIN_BLOCK_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "PIN block must be exactly 8 bytes."));
+
+    EXCEPTION_ASSERT_WITH_LOG(iccNumber.size() == ICC_NUMBER_SIZE,
+        LibLogicalAccessException, sam::errorMessage(__func__, "ICC number must be exactly 8 bytes."));
+
     ByteVector apdu;
-    apdu.reserve(5 + 16 + 1);
-    apdu = {d_cla, sam::ins::emv::EncipherPin, 0x00, 0x00, 0x10};
+    apdu.reserve(sam::APDU_HEADER_WITH_LE_SIZE + PAYLOAD_SIZE);
+    apdu.push_back(d_cla);
+    apdu.push_back(sam::ins::emv::EncipherPin);
+    apdu.push_back(0x00);
+    apdu.push_back(0x00);
+    apdu.push_back(static_cast<unsigned char>(PAYLOAD_SIZE));
     apdu.insert(apdu.end(), pinBlock.begin(), pinBlock.end());
     apdu.insert(apdu.end(), iccNumber.begin(), iccNumber.end());
-    apdu.push_back(0x00);
+    apdu.push_back(LE_EXPECT_RESPONSE);
 
-    const ByteVector result = transmit(apdu, true, true, true);
-    if (result.size() < 2)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "SAM_EncipherPIN : response too short");
-
-    const uint16_t sw = (result[result.size() - 2] << 8) | result[result.size() - 1];
-
-    if (sw != 0x9000)
-        THROW_EXCEPTION_WITH_LOG(LibLogicalAccessException,
-                                 "SAM_EncipherPIN : unexpected status word");
-
-    return ByteVector(result.begin(), result.end() - 2);
+    ByteVector response = executeProtectedExchange(apdu, sam::ApduFormat::Standard, sam::EMV_LAYOUT);
+    validateSuccessResponse(response, __func__);
+    response.resize(response.size() - sam::STATUS_WORD_SIZE);
+    return response;
 }
-
 
 }

--- a/plugins/logicalaccess/plugins/readers/iso7816/commands/samav3iso7816commands.cpp
+++ b/plugins/logicalaccess/plugins/readers/iso7816/commands/samav3iso7816commands.cpp
@@ -41,7 +41,7 @@ ByteVector SAMAV3ISO7816Commands::encipherKeyEntry(
         data.insert(data.end(), divInput.begin(), divInput.end());
     }
     auto result = getISO7816ReaderCardAdapter()->sendAPDUCommand(
-        d_cla, 0xE1, keyno, p2, static_cast<unsigned char>(data.size()), data, 0x00);
+        d_cla, sam::ins::key::EncipherKeyEntry, keyno, p2, static_cast<unsigned char>(data.size()), data, 0x00);
     return result.getData();
 }
 
@@ -107,7 +107,7 @@ void SAMAV3ISO7816Commands::PKI_ImportCaPk(
         ByteVector apdu;
         apdu.reserve(5 + data.size() + 1);
         apdu.push_back(d_cla);
-        apdu.push_back(0x24);
+        apdu.push_back(sam::ins::emv::ImportCaPk);
         apdu.push_back(p1);
         apdu.push_back(settingsOnly ? 0x80 : 0x00);
         apdu.push_back(static_cast<unsigned char>(data.size()));
@@ -174,7 +174,7 @@ ByteVector SAMAV3ISO7816Commands::PKI_ImportCaPkOffline(const ByteVector &offlin
         ByteVector apdu;
         apdu.reserve(5 + data.size() + (requestAck ? 1 : 0));
         apdu.push_back(d_cla);
-        apdu.push_back(0x24);
+        apdu.push_back(sam::ins::emv::ImportCaPk);
         apdu.push_back(p1);
         apdu.push_back(settingsOnly ? 0x80 : 0x00);
         apdu.push_back(static_cast<unsigned char>(data.size()));
@@ -243,7 +243,7 @@ void SAMAV3ISO7816Commands::PKI_RemoveCaPk(const ByteVector &rid,
     ByteVector apdu;
     apdu.reserve(5 + 6);
     apdu.push_back(d_cla);
-    apdu.push_back(0x2F);
+    apdu.push_back(sam::ins::emv::RemoveCaPk);
     apdu.push_back(0x00);
     apdu.push_back(0x00);
     apdu.push_back(0x06);
@@ -281,7 +281,7 @@ ByteVector SAMAV3ISO7816Commands::PKI_RemoveCaPkOffline(const ByteVector &offlin
     ByteVector apdu;
     apdu.reserve(5 + offlineCryptogram.size() + (requestAck ? 1 : 0));
     apdu.push_back(d_cla);
-    apdu.push_back(0x2F);
+    apdu.push_back(sam::ins::emv::RemoveCaPk);
     apdu.push_back(0x00);
     apdu.push_back(0x00);
     apdu.push_back(0x1A);
@@ -341,7 +341,7 @@ ByteVector SAMAV3ISO7816Commands::PKI_ExportCaPk(const ByteVector &rid,
         ByteVector apdu;
         apdu.reserve(5 + data.size() + 1);
         apdu.push_back(d_cla);
-        apdu.push_back(0x3D);
+        apdu.push_back(sam::ins::emv::ExportCaPk);
         apdu.push_back(p1);
         apdu.push_back(0x00);
         apdu.push_back(static_cast<unsigned char>(data.size()));
@@ -439,7 +439,7 @@ ByteVector SAMAV3ISO7816Commands::PKI_LoadIssuerPk(
         ByteVector apdu;
         apdu.reserve(5 + data.size() + 1);
         apdu.push_back(d_cla);
-        apdu.push_back(0x27);
+        apdu.push_back(sam::ins::emv::LoadIssuerPk);
         apdu.push_back(p1);
         apdu.push_back(0x00);
         apdu.push_back(static_cast<uint8_t>(data.size()));
@@ -526,7 +526,7 @@ ByteVector SAMAV3ISO7816Commands::PKI_LoadIccPk(const ByteVector &iccPkCert,
         ByteVector apdu;
         apdu.reserve(5 + data.size() + 1);
         apdu.push_back(d_cla);
-        apdu.push_back(0x28);
+        apdu.push_back(sam::ins::emv::LoadIccPk);
         apdu.push_back(p1);
         apdu.push_back(0x00);
         apdu.push_back(static_cast<unsigned char>(data.size()));
@@ -592,7 +592,7 @@ ByteVector SAMAV3ISO7816Commands::SAM_RecoverStaticData(const ByteVector &ssad)
         ByteVector apdu;
         apdu.reserve(5 + data.size() + 1);
         apdu.push_back(d_cla);
-        apdu.push_back(0x29);
+        apdu.push_back(sam::ins::emv::RecoverStaticData);
         apdu.push_back(p1);
         apdu.push_back(0x00);
         apdu.push_back(static_cast<unsigned char>(data.size()));
@@ -658,7 +658,7 @@ ByteVector SAMAV3ISO7816Commands::SAM_RecoverDynamicData(const ByteVector &sdad)
         ByteVector apdu;
         apdu.reserve(5 + data.size() + 1);
         apdu.push_back(d_cla);
-        apdu.push_back(0x2A);
+        apdu.push_back(sam::ins::emv::RecoverDynamicData);
         apdu.push_back(p1);
         apdu.push_back(0x00);
         apdu.push_back(static_cast<unsigned char>(data.size()));
@@ -716,7 +716,7 @@ ByteVector SAMAV3ISO7816Commands::SAM_EncipherPIN(const ByteVector &pinBlock,
                                  "SAM_EncipherPIN : ICC number must be exactly 8 bytes");
     ByteVector apdu;
     apdu.reserve(5 + 16 + 1);
-    apdu = {d_cla, 0x2B, 0x00, 0x00, 0x10};
+    apdu = {d_cla, sam::ins::emv::EncipherPin, 0x00, 0x00, 0x10};
     apdu.insert(apdu.end(), pinBlock.begin(), pinBlock.end());
     apdu.insert(apdu.end(), iccNumber.begin(), iccNumber.end());
     apdu.push_back(0x00);

--- a/plugins/logicalaccess/plugins/readers/iso7816/commands/samav3iso7816commands.hpp
+++ b/plugins/logicalaccess/plugins/readers/iso7816/commands/samav3iso7816commands.hpp
@@ -8,13 +8,13 @@
 #define LOGICALACCESS_SAMAV3ISO7816CARDPROVIDER_HPP
 
 #include <logicalaccess/plugins/cards/samav/samav3commands.hpp>
-#include <logicalaccess/plugins/readers/iso7816/commands/samav2iso7816commands.hpp>
-#include <logicalaccess/plugins/cards/iso7816/readercardadapters/iso7816readercardadapter.hpp>
-#include <logicalaccess/plugins/readers/iso7816/iso7816readerunitconfiguration.hpp>
+#include <logicalaccess/plugins/cards/samav/samav2commands.hpp>
 #include <logicalaccess/plugins/cards/samav/samcrypto.hpp>
 #include <logicalaccess/plugins/cards/samav/samkeyentry.hpp>
-#include <logicalaccess/plugins/cards/samav/samcrypto.hpp>
-#include <logicalaccess/plugins/cards/samav/samav2commands.hpp>
+#include <logicalaccess/plugins/readers/iso7816/commands/samav2iso7816commands.hpp>
+#include <logicalaccess/plugins/readers/iso7816/iso7816readerunitconfiguration.hpp>
+#include <logicalaccess/plugins/cards/iso7816/readercardadapters/iso7816readercardadapter.hpp>
+
 #include <string>
 #include <vector>
 #include <iostream>
@@ -45,48 +45,39 @@ class LLA_READERS_ISO7816_API SAMAV3ISO7816Commands
      * \brief Destructor.
      */
     virtual ~SAMAV3ISO7816Commands();
-    
-    ByteVector encipherKeyEntry(unsigned char keyno,
-                          unsigned char targetKeyno,
-                          unsigned short changeCounter,
-                          unsigned char channel = 0,
-                          const ByteVector& targetSamUid = ByteVector(),
-                          const ByteVector& divInput = ByteVector()) override;
 
-    void PKI_ImportCaPk(const ByteVector &rid, unsigned char pkId,
-                              unsigned short set, unsigned char keyNoCEK,
-                              unsigned char keyVCEK, unsigned char keyNoAEK,
-                              unsigned char keyVAEK, unsigned char pkExpLen,
-                              const ByteVector &pk    = ByteVector(),
-                              const ByteVector &pkExp = ByteVector(),
-                              bool settingsOnly       = false) override;
+    ByteVector encipherKeyEntry(unsigned char keyno, unsigned char targetKeyno,
+                                unsigned short changeCounter, unsigned char channel = 0,
+                                const ByteVector &targetSamUid = ByteVector(),
+                                const ByteVector &divInput     = ByteVector()) override;
+
+    void PKI_ImportCaPk(const ByteVector &rid, unsigned char pkId, unsigned short set,
+                        unsigned char keyNoCEK, unsigned char keyVCEK,
+                        unsigned char keyNoAEK, unsigned char keyVAEK,
+                        unsigned char pkExpLen, const ByteVector &pk = ByteVector(),
+                        const ByteVector &pkExp = ByteVector(), bool settingsOnly = false) override;
 
     ByteVector PKI_ImportCaPkOffline(const ByteVector &offlineCryptogram,
-                                     bool settingsOnly, bool requestAck) override;
+                                     bool settingsOnly, bool expectResponseData) override;
 
     void PKI_RemoveCaPk(const ByteVector &rid, unsigned char pkId) override;
 
-    ByteVector PKI_RemoveCaPkOffline(const ByteVector &offlineCryptogram,
-                                     bool requestAck) override;
+    ByteVector PKI_RemoveCaPkOffline(const ByteVector &offlineCryptogram, bool expectResponseData) override;
 
-    ByteVector PKI_ExportCaPk(const ByteVector &rid, unsigned char pkId,
-                                      bool settingsOnly) override;
+    ByteVector PKI_ExportCaPk(const ByteVector &rid, unsigned char pkId, bool settingsOnly) override;
 
     ByteVector PKI_LoadIssuerPk(const ByteVector &rid, unsigned char pkId,
-                                        const ByteVector &issuerPkCert,
-                                        const ByteVector &issuerPkRemainder,
-                                        unsigned char pkExpLen) override;
+                                const ByteVector &issuerPkCert, const ByteVector &issuerPkRemainder,
+                                unsigned char pkExpLen) override;
 
-    ByteVector PKI_LoadIccPk(const ByteVector &iccPkCert,
-                                     const ByteVector &iccPkRemainder,
-                                     const ByteVector &staticData, unsigned char pkExpLen) override;
+    ByteVector PKI_LoadIccPk(const ByteVector &iccPkCert, const ByteVector &iccPkRemainder,
+                             const ByteVector &staticData, unsigned char pkExpLen) override;
 
     ByteVector SAM_RecoverStaticData(const ByteVector &ssad) override;
 
     ByteVector SAM_RecoverDynamicData(const ByteVector &sdad) override;
 
-    ByteVector SAM_EncipherPIN(const ByteVector &pinBlock,
-                                       const ByteVector &iccNumber) override;
+    ByteVector SAM_EncipherPIN(const ByteVector &pinBlock, const ByteVector &iccNumber) override;
 
     std::shared_ptr<Chip> getChip() const override
     {

--- a/samples/basic/basic_pki.cpp
+++ b/samples/basic/basic_pki.cpp
@@ -2,9 +2,7 @@
 #include <logicalaccess/readerproviders/readerconfiguration.hpp>
 #include <logicalaccess/plugins/readers/iso7816/commands/samav3iso7816commands.hpp>
 
-#include <openssl/evp.h>
-#include <openssl/core_names.h>
-#include <openssl/bn.h>
+#include <ctime>
 
 using namespace logicalaccess;
 
@@ -24,17 +22,17 @@ enum class HashAlgo : unsigned char
 using Config = uint16_t;
 
 // PKI configuration flags
-constexpr Config PUBLIC_KEY                    = 0;
-constexpr Config PRIVATE_KEY                   = (1u << 0);
-constexpr Config ALLOW_PRIVATE_EXPORT          = (1u << 1);
-constexpr Config DISABLE                       = (1u << 2);
-constexpr Config DISABLE_ENCRYPTION            = (1u << 3);
-constexpr Config DISABLE_SIGNATURE             = (1u << 4);
-constexpr Config UPDATE_KEY_ENTRIES            = (1u << 5);
-constexpr Config CRT                           = (1u << 6);
-constexpr Config ENCIPHER_KEYS                 = (1u << 7);
-constexpr Config FORCE_HOST_USAGE              = (1u << 8);
-constexpr Config FORCE_HOST_CHANGE             = (1u << 9);
+constexpr Config PUBLIC_KEY           = 0;
+constexpr Config PRIVATE_KEY          = (1u << 0);
+constexpr Config ALLOW_PRIVATE_EXPORT = (1u << 1);
+constexpr Config DISABLE              = (1u << 2);
+constexpr Config DISABLE_ENCRYPTION   = (1u << 3);
+constexpr Config DISABLE_SIGNATURE    = (1u << 4);
+constexpr Config UPDATE_KEY_ENTRIES   = (1u << 5);
+constexpr Config CRT                  = (1u << 6);
+constexpr Config ENCIPHER_KEYS        = (1u << 7);
+constexpr Config FORCE_HOST_USAGE     = (1u << 8);
+constexpr Config FORCE_HOST_CHANGE    = (1u << 9);
 // Test defaults
 constexpr uint8_t DEFAULT_KUC    = 0xFE;
 constexpr uint8_t DEFAULT_CEKNO  = 0x00;
@@ -42,9 +40,11 @@ constexpr uint8_t DEFAULT_CEKVER = 0xFF;
 constexpr uint8_t FIRST_SLOT     = 0x00;
 constexpr uint8_t LAST_SLOT      = 0x02;
 
-const Config TEST_KEY = PRIVATE_KEY | ALLOW_PRIVATE_EXPORT | UPDATE_KEY_ENTRIES | ENCIPHER_KEYS | CRT;
+constexpr Config TEST_KEY = PRIVATE_KEY | ALLOW_PRIVATE_EXPORT | UPDATE_KEY_ENTRIES | ENCIPHER_KEYS | CRT;
 
-const Config TEST_KEY_SAFE = PRIVATE_KEY | ALLOW_PRIVATE_EXPORT | CRT;
+constexpr Config TEST_KEY_SAFE = PRIVATE_KEY | ALLOW_PRIVATE_EXPORT | CRT;
+
+constexpr Config TEST_KEY_DISABLED = TEST_KEY_SAFE | DISABLE;
 }
 
 struct PKIImportTestCase
@@ -187,6 +187,7 @@ struct PKIGenerateTestCase
     unsigned char keyNoRef{};
     sam::AEKVAEK accessKeys{};
     unsigned short nLen{};
+    unsigned short eLen{};
     ByteVector pki_e{};
     bool includeAccess{};
     bool expectSuccess{};
@@ -593,49 +594,62 @@ std::vector<PKIImportTestCase> importTests = {
 
 std::vector<PKIGenerateTestCase> generateKeyPairTests = {
     // ===== SUCCESS =====
-    {0x01, 0x0001, 0xFE, 0x00, 0xFF, sam::AEKVAEK{}, 0x40, {}, false, true, false, "Valid parameters, random exponent, minimal modulus"},
-    {0x00, 0x0001, 0xFE, 0x00, 0xFF, sam::AEKVAEK{}, 0x100, ByteVector(256, 0x03), false, true, false, "APDU chaining with large exponent (no access)"},
-    {0x01, pki::PRIVATE_KEY | pki::ALLOW_PRIVATE_EXPORT | pki::CRT, 0xFE, 0x00, 0xFF, sam::AEKVAEK{}, 0x40, {}, false, true, false, "Valid config without access keys"},
+    {0x01, pki::PRIVATE_KEY, pki::DEFAULT_KUC, pki::DEFAULT_CEKNO, pki::DEFAULT_CEKVER, sam::AEKVAEK{}, 0x40, 0x04,
+    {}, false, true, false, "Valid parameters, random exponent, minimal modulus"},
+
+    {0x00, pki::PRIVATE_KEY, pki::DEFAULT_KUC, pki::DEFAULT_CEKNO, pki::DEFAULT_CEKVER, sam::AEKVAEK{}, 0x100, 0x100,
+    ByteVector(256, 0x03), false, true, false, "APDU chaining with large exponent (no access)"},
+
+    {0x01, pki::TEST_KEY_SAFE, pki::DEFAULT_KUC, pki::DEFAULT_CEKNO, pki::DEFAULT_CEKVER, sam::AEKVAEK{}, 0x40, 0x04,
+    {}, false, true, false, "Valid config without access keys"},
 
     // ===== DISABLED KEY =====
-    {0x01, pki::PRIVATE_KEY | pki::ALLOW_PRIVATE_EXPORT | pki::CRT, 0xFE, 0x00, 0xFF, sam::AEKVAEK{}, 0x40, {}, false, true, true, "Key generation with disable flag (bit 2 set)"},
+    {0x01, pki::TEST_KEY_DISABLED, pki::DEFAULT_KUC, pki::DEFAULT_CEKNO, pki::DEFAULT_CEKVER, sam::AEKVAEK{}, 0x40, 0x04,
+    {}, false, true, true, "Key generation with disable flag (bit 2 set)"},
 
     // ===== MIN EXPONENT SIZE =====
-    {0x01, 0x0001, 0xFE, 0x00, 0xFF, sam::AEKVAEK{}, 0x40, logicalaccess::BufferHelper::fromHexString("00000003"), false, true, false,
-     "Minimum valid exponent size (4 bytes and odd)"},
+    {0x01, pki::PRIVATE_KEY, pki::DEFAULT_KUC, pki::DEFAULT_CEKNO, pki::DEFAULT_CEKVER, sam::AEKVAEK{}, 0x40, 0x04,
+    logicalaccess::BufferHelper::fromHexString("00000003"), false, true, false, "Minimum valid exponent size (4 bytes and odd)"},
 
     // ===== EXPONENT (SMALL) =====
-    {0x01, 0x0001, 0xFE, 0x00, 0xFF, sam::AEKVAEK{}, 0x40, logicalaccess::BufferHelper::fromHexString("00010001"), false, true, false,
-     "Standard RSA exponent (65537)"},
+    {0x01, pki::PRIVATE_KEY, pki::DEFAULT_KUC, pki::DEFAULT_CEKNO, pki::DEFAULT_CEKVER, sam::AEKVAEK{}, 0x40, 0x04,
+    logicalaccess::BufferHelper::fromHexString("00010001"), false, true, false, "Standard RSA exponent (65537)"},
 
     // ===== CHAINING =====
-    {0x01, 0x0001, 0xFE, 0x00, 0xFF, sam::AEKVAEK{}, 0x100, ByteVector(256, 0x03), false, true, false, "APDU chaining (256-byte exponent)"},
+    {0x01, pki::PRIVATE_KEY, pki::DEFAULT_KUC, pki::DEFAULT_CEKNO, pki::DEFAULT_CEKVER, sam::AEKVAEK{}, 0x100, 0x100,
+    ByteVector(256, 0x03), false, true, false, "APDU chaining (256-byte exponent)"},
     
     // ===== INVALID KEY NUMBER =====
-    {0x02, 0x0001, 0xFE, 0x00, 0xFF, sam::AEKVAEK{}, 0x40, {}, false, false, false, "Invalid key number (must be 0x00 or 0x01)"},
+    {0x02, pki::PRIVATE_KEY, pki::DEFAULT_KUC, pki::DEFAULT_CEKNO, pki::DEFAULT_CEKVER, sam::AEKVAEK{}, 0x40, 0x04,
+    {}, false, false, false, "Invalid key number (must be 0x00 or 0x01)"},
 
     // ===== INCORRECT EXPONENT LENGTH (SMALL) =====
-    {0x01, 0x0001, 0xFE, 0x00, 0xFF, sam::AEKVAEK{}, 0x40, logicalaccess::BufferHelper::fromHexString("010001"), false, false, false,
-     "Exponent length not multiple of 4 bytes"},
+    {0x01, pki::PRIVATE_KEY, pki::DEFAULT_KUC, pki::DEFAULT_CEKNO, pki::DEFAULT_CEKVER, sam::AEKVAEK{}, 0x40, 0x03,
+    logicalaccess::BufferHelper::fromHexString("010001"), false, false, false, "Exponent length not multiple of 4 bytes"},
 
     // ===== INCORRECT EXPONENT (EVEN) =====
-    {0x01, 0x0001, 0xFE, 0x00, 0xFF, sam::AEKVAEK{}, 0x40, logicalaccess::BufferHelper::fromHexString("020002"), false, false, false,
-     "Exponent must be odd"},
+    {0x01, pki::PRIVATE_KEY, pki::DEFAULT_KUC, pki::DEFAULT_CEKNO, pki::DEFAULT_CEKVER, sam::AEKVAEK{}, 0x40, 0x04,
+    logicalaccess::BufferHelper::fromHexString("020002"), false, false, false, "Exponent must be odd"},
 
     // ===== AEK (DISABLE CONFLICT) =====
-    {0x01, 0x0004, 0xFE, 0x00, 0xFF, sam::AEKVAEK{}, 0x40, {}, true, false, false, "Access keys required but not provided"},
+    {0x01, pki::DISABLE, pki::DEFAULT_KUC, pki::DEFAULT_CEKNO, pki::DEFAULT_CEKVER, sam::AEKVAEK{}, 0x40, 0x04,
+    {}, true, false, false, "Access keys required but not provided"},
 
     // ===== INVALID NLEN =====
-    {0x01, 0x0001, 0xFE, 0x00, 0xFF, sam::AEKVAEK{}, 0x41, {}, false, false, false, "Modulus length not multiple of 8"},
+    {0x01, pki::PRIVATE_KEY, pki::DEFAULT_KUC, pki::DEFAULT_CEKNO, pki::DEFAULT_CEKVER, sam::AEKVAEK{}, 0x41, 0x04,
+    {}, false, false, false, "Modulus length not multiple of 8"},
 
     // ===== EXPONENT > MODULUS =====
-    {0x01, 0x0001, 0xFE, 0x00, 0xFF, sam::AEKVAEK{}, 0x40, ByteVector(128, 0x03), false, false, false, "Exponent length greater than modulus"},
+    {0x01, pki::PRIVATE_KEY, pki::DEFAULT_KUC, pki::DEFAULT_CEKNO, pki::DEFAULT_CEKVER, sam::AEKVAEK{}, 0x40, 0x80,
+    ByteVector(128, 0x03), false, false, false, "Exponent length greater than modulus"},
 
     // ===== AEK WITH DISABLED KEY (CONFLICT) =====
-    {0x01, 0x0004, 0xFE, 0x00, 0xFF, sam::AEKVAEK(0x10, 0x20), 0x40, {}, false, false, false, "Access key provided while key is disabled"},
+    {0x01, pki::DISABLE, pki::DEFAULT_KUC, pki::DEFAULT_CEKNO, pki::DEFAULT_CEKVER, sam::AEKVAEK(0x10, 0x20), 0x40, 0x04,
+    {}, false, false, false, "Access key provided while key is disabled"},
 
     // ===== NLEN TOO SMALL =====
-    {0x01, 0x0001, 0xFE, 0x00, 0xFF, sam::AEKVAEK{}, 0x20, {},false, false, false, "Modulus length too small (64 bytes required)"}
+    {0x01, pki::PRIVATE_KEY, pki::DEFAULT_KUC, pki::DEFAULT_CEKNO, pki::DEFAULT_CEKVER, sam::AEKVAEK{}, 0x20, 0x04,
+    {},false, false, false, "Modulus length too small (64 bytes required)"}
 };
 
 std::vector<PKIUpdateKeyEntriesTestCase> updateKeyEntriesTests = {
@@ -746,7 +760,7 @@ std::vector<PKISendSignatureTestCase> sendSignatureTests = {
     {true, true, "Retrieve signature third time"},
 
     // ===== STATE DEPENDENCY =====
-    {false, false, "No signature available"} //Test will fail if signature present (with previous tests)
+    {false, false, "No signature available"} //Test cannot fail if signature present (generated with previous runPKI tests)
 };
 
 struct TestStats
@@ -844,7 +858,7 @@ void runPKIGenerateTests(std::shared_ptr<SAMAV3ISO7816Commands> samCmd, const Te
         [&](const PKIGenerateTestCase &tc)
         {
             samCmd->PKI_GenerateKeyPair(tc.keyNo, tc.config, tc.keyNoCEK, tc.keyNoVCEK,
-                                        tc.keyNoRef, tc.accessKeys, tc.nLen, tc.pki_e,
+                                        tc.keyNoRef, tc.accessKeys, tc.nLen, tc.eLen, tc.pki_e,
                                         tc.includeAccess);
         },
         [&](const PKIGenerateTestCase &tc, bool success)
@@ -1283,15 +1297,15 @@ ByteVector makeSafeEccPoint()
 static const ByteVector SAFE_ECC_POINT = {
     0x04,
     // X (32 bytes)
-    0x11,0x11,0x11,0x11,0x11,0x11,0x11,0x11,
-    0x11,0x11,0x11,0x11,0x11,0x11,0x11,0x11,
-    0x22,0x22,0x22,0x22,0x22,0x22,0x22,0x22,
-    0x22,0x22,0x22,0x22,0x22,0x22,0x22,0x22,
+    0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+    0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11, 0x11,
+    0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
+    0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22, 0x22,
     // Y (32 bytes)
-    0x33,0x33,0x33,0x33,0x33,0x33,0x33,0x33,
-    0x33,0x33,0x33,0x33,0x33,0x33,0x33,0x33,
-    0x44,0x44,0x44,0x44,0x44,0x44,0x44,0x44,
-    0x44,0x44,0x44,0x44,0x44,0x44,0x44,0x44
+    0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33,
+    0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33, 0x33,
+    0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44,
+    0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44, 0x44
 };
 
 std::vector<PKIImportEccTestCase> importEccKeyTests = {
@@ -1318,9 +1332,9 @@ void runPKIImportEccTests(std::shared_ptr<SAMAV3ISO7816Commands> samCmd, const T
         {
             std::cout << "[INFO] " << tc.description << " -> " << (success ? "OK" : "FAIL") << '\n';
             if (!success && tc.expectSuccess)
-                throw std::runtime_error("Unexpected ECC import failure: " + tc.description);
+                throw std::runtime_error("Unexpected ECC import failure : " + tc.description);
             if (success && !tc.expectSuccess)
-                throw std::runtime_error("Unexpected ECC import success: " + tc.description);
+                throw std::runtime_error("Unexpected ECC import success : " + tc.description);
         },
         hooks);
 }
@@ -1341,8 +1355,10 @@ struct ECCCurveBuilder
                                      uint8_t fillA, uint8_t fillB, uint8_t fillPx,
                                      uint8_t fillPy, uint8_t fillOrder)
     {
+        constexpr std::size_t HEADER_SIZE = 2;
+        constexpr std::size_t FIELD_COUNT = 5;
         ByteVector v;
-        v.reserve(2 + 5 * eccN + eccM);
+        v.reserve(HEADER_SIZE + FIELD_COUNT * static_cast<std::size_t>(eccN) + static_cast<std::size_t>(eccM));
         v.push_back(eccN);
         v.push_back(eccM);
         auto appendN = [&](uint8_t val) { v.insert(v.end(), eccN, val); };
@@ -1497,7 +1513,7 @@ struct SamSession
                 "00000000000000000000000000000000"));
         }
         // Select the desired SAM host authentication mode by uncommenting the corresponding overload
-        samCmd->SAMAV2ISO7816Commands::authenticateHost(hostKey, 0x00);
+        samCmd->SAMAV2ISO7816Commands::authenticateHost(hostKey, 0x00); //FullProtect by default
         //samCmd->SAMAV2ISO7816Commands::authenticateHost(hostKey, 0x00, sam::HostMode::MAC);
         //samCmd->SAMAV2ISO7816Commands::authenticateHost(hostKey, 0x00, sam::HostMode::Plain);
     }
@@ -1521,7 +1537,8 @@ int main(int, char **)
         readerSession.readerConfig = readerConfig;
         std::cout << "Waiting 15 seconds for card insertion..." << std::endl;
         readerSession.connect();
-        std::cout << "[INFO] Time start : " << time(NULL) << std::endl;
+        const auto now = std::time(nullptr);
+        std::cout << "[INFO] Time start : " << std::ctime(&now);
         readerSession.waitCard();
         std::cout << "[INFO] Card type : " << readerSession.chip->getCardType() << std::endl;
         samSession.attach(readerSession.chip);
@@ -1541,7 +1558,7 @@ int main(int, char **)
             }
             catch (const std::exception &e)
             {
-                std::cout << "[HOOK] Disconnect failed: " << e.what() << std::endl;
+                std::cout << "[HOOK] Disconnect failed : " << e.what() << std::endl;
             }
             catch (...)
             {
@@ -1554,7 +1571,7 @@ int main(int, char **)
             samSession.authenticate();
             std::cout << "[HOOK] SAM authenticated" << std::endl;
         };
-        for (int session = 0; session < 1; ++session) //Will be improved later
+        for (int session = 0; session < 1; ++session) // Will be improved later
         {
             std::cout << "\n=== TEST SESSION " << session << " ===\n";
 

--- a/samples/basic/basic_pki.cpp
+++ b/samples/basic/basic_pki.cpp
@@ -1227,7 +1227,7 @@ std::vector<PKIRoundTripTestCase> roundTripTests = {
 
     // ===== REPEATABILITY =====
     {0x03, 0x00, ByteVector(16, 0x55), true, "Repeatability #1"},
-    {0x03, 0x00, ByteVector(16, 0x55), true, "Repeatability #2"},
+    {0x03, 0x00, ByteVector(16, 0x55), true, "Repeatability #2"}
 };
 
 void runPKIRoundTripTests(std::shared_ptr<logicalaccess::SAMAV3ISO7816Commands> samCmd, const TestHooks& hooks)
@@ -1244,6 +1244,7 @@ void runPKIRoundTripTests(std::shared_ptr<logicalaccess::SAMAV3ISO7816Commands> 
             //     throw std::runtime_error("OAEP randomness failure");
             if (encrypted.empty())
                 throw std::runtime_error("Empty ciphertext");
+
             // ByteVector decrypted2 = samCmd->PKI_DecipherData(tc.hashAlgo,
             // tc.keyNo, encrypted); if (decrypted != tc.plainData || decrypted2 != tc.plainData)
             //      throw std::runtime_error("Roundtrip mismatch");
@@ -1336,7 +1337,7 @@ struct PKIImportEccCurveTestCase
 };
 struct ECCCurveBuilder
 {
-    static ByteVector BuildFakeCurve(uint8_t eccN, uint8_t eccM, uint8_t fillPrime,
+    static ByteVector BuildCurve(uint8_t eccN, uint8_t eccM, uint8_t fillPrime,
                                      uint8_t fillA, uint8_t fillB, uint8_t fillPx,
                                      uint8_t fillPy, uint8_t fillOrder)
     {
@@ -1356,10 +1357,7 @@ struct ECCCurveBuilder
 };
 
 std::vector<PKIImportEccCurveTestCase> ImportEccCurveTests = {
-    {0x00, 0xFE, 0x00,
-     ECCCurveBuilder::BuildFakeCurve(0x10,
-                                     0x10,
-                                     0x11, 0x22, 0x33, 0x44, 0x55, 0x66),
+    {0x00, 0xFE, 0x00, ECCCurveBuilder::BuildCurve(0x10, 0x10, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66),
      false, true, "Valid ECC curve (minimal safe size)"}};
 
 
@@ -1498,7 +1496,10 @@ struct SamSession
             hostKey->setData(logicalaccess::BufferHelper::fromHexString(
                 "00000000000000000000000000000000"));
         }
+        // Select the desired SAM host authentication mode by uncommenting the corresponding overload
         samCmd->SAMAV2ISO7816Commands::authenticateHost(hostKey, 0x00);
+        //samCmd->SAMAV2ISO7816Commands::authenticateHost(hostKey, 0x00, sam::HostMode::MAC);
+        //samCmd->SAMAV2ISO7816Commands::authenticateHost(hostKey, 0x00, sam::HostMode::Plain);
     }
 };
 


### PR DESCRIPTION
This PR modernizes the entire SAMAV2ISO7816Commands implementation while preserving protocol compatibility : it improve correctness, robustness, maintainability, and consistency across the entire command layer.
The resulting codebase is more maintainable : consistent APDU construction, stronger parameter validation, centralized secure messaging, unified response handling and some correctness fixes.

- APDU transmission and secure messaging :
  - Added explicit support for the three secure messaging modes (Plain, Mac protection, Full protection)
  - Added host mode state tracking through d_hostMode
  - Added explicit host mode state reset using HostMode::None
  - Introduced a protected exchange mechanism to handle multiple specialized secure transmission paths
  - Refactored APDU transmission layer to separate transport from secure messaging
  - Centralized secure messaging processing
  - Added explicit APDU format handling
  - Added secure cleanup of sensitive buffers after authentication
- Secure messaging payload handling :
  - Unified construction of protected APDUs
  - Removed duplicated payload construction code
- Serialization improvements :
  - Replaced manual endian conversions with helper functions
  - Improved readability and reduced possibilities for serialization bugs
- Command definitions :
  - Replaced hardcoded instruction bytes with named instruction constants (sam::ins::)
  - Added named constants when possible (ie. SW size, max APDU size).
  - Centralized protocol definitions
- Response validation :
  - Replaced manual status word checks with helper validateSuccessResponse()
  - Improved malformed APDU detection and invalid response handling
  - Added consistent response size validation before parsing response data
- Parameter validation :
  - Standardized argument validation with EXCEPTION_ASSERT_WITH_LOG
  - Added descriptive function-specific error messages
- Memory and optimization :
  - Replaced some allocation patterns
  - Removed unnecessary mutable variables where possible
  - Improved object management and reduced temporary allocations
- Bug fixes :
  - Corrected several APDU construction inconsistencies.
  - Fixed response size validation before parsing command output
  - Fixed incorrect status word verification in getKUCEntry()
  - Fixed inconsistent response validation across multiple commands